### PR TITLE
Add linter CI/CD for Go daemon

### DIFF
--- a/.github/workflows/daemon.yaml
+++ b/.github/workflows/daemon.yaml
@@ -47,4 +47,4 @@ jobs:
         with:
           working-directory: daemon
           version: v1.61.0
-          args: "--timeout=10m "
+          args: "--timeout=10m"

--- a/.github/workflows/daemon.yaml
+++ b/.github/workflows/daemon.yaml
@@ -8,6 +8,7 @@ on:
       - "master"
     paths:
       - "daemon/**"
+      - ".github/workflows/daemon.yaml"
 
     tags:
       - "*"
@@ -17,6 +18,7 @@ on:
       - master
     paths:
       - "daemon/**"
+      - ".github/workflows/daemon.yaml"
 
     types:
       - opened

--- a/.github/workflows/daemon.yaml
+++ b/.github/workflows/daemon.yaml
@@ -1,0 +1,50 @@
+name: Daemon
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches:
+      - "master"
+    paths:
+      - "daemon/**"
+
+    tags:
+      - "*"
+
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "daemon/**"
+
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+concurrency:
+  # Cancel any previous workflows if they are from a PR or push.
+  group: ${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  GO_VERSION: 1.23.1
+
+jobs:
+  go-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          working-directory: daemon
+          version: v1.61.0
+          args: "--timeout=10m "


### PR DESCRIPTION
Introduce a GitHub Actions workflow to run a linter on the Go daemon codebase