### PR TITLE
Add network support to the server

### DIFF
--- a/daemon/cmd/main.go
+++ b/daemon/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	swapcli "github.com/40acres/40swap/daemon/cli"
 	"github.com/40acres/40swap/daemon/daemon"
 	"github.com/40acres/40swap/daemon/database"
+	"github.com/40acres/40swap/daemon/rpc"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v3"
 
@@ -80,6 +81,8 @@ func main() {
 				Value: false,
 			},
 			&grpcPort,
+			&testnet,
+			&regtest,
 		},
 		Commands: []*cli.Command{
 			{
@@ -123,7 +126,15 @@ func main() {
 						log.Info("🔍 Skipping database migration")
 					}
 
-					err = daemon.Start(ctx, db, grpcPort)
+					// Get the network
+					network := rpc.Network_MAINNET
+					if c.Bool("regtest") {
+						network = rpc.Network_REGTEST
+					} else if c.Bool("testnet") {
+						network = rpc.Network_TESTNET
+					}
+
+					err = daemon.Start(ctx, db, grpcPort, network)
 					if err != nil {
 						return err
 					}

--- a/daemon/daemon/daemon.go
+++ b/daemon/daemon/daemon.go
@@ -9,11 +9,11 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func Start(ctx context.Context, db *database.Database, grpcPort uint32) error {
+func Start(ctx context.Context, db *database.Database, grpcPort uint32, network rpc.Network) error {
 	log.Info("Starting 40swapd")
 
 	// gRPC server
-	server := rpc.NewRPCServer(grpcPort, db)
+	server := rpc.NewRPCServer(grpcPort, db, network)
 	defer server.Stop()
 	go func() {
 		err := server.ListenAndServe()

--- a/daemon/rpc/client_test.go
+++ b/daemon/rpc/client_test.go
@@ -31,7 +31,7 @@ func TestClientInvalidRequest(test *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	port := uint32(50051)
-	server := NewRPCServer(port, nil)
+	server := NewRPCServer(port, nil, Network_REGTEST)
 	errChan := make(chan error)
 	go func() {
 		errChan <- server.ListenAndServe()

--- a/daemon/rpc/server.go
+++ b/daemon/rpc/server.go
@@ -16,13 +16,15 @@ type Server struct {
 	Port       uint32
 	Repository Repository
 	grpcServer *grpc.Server
+	network    Network
 }
 
-func NewRPCServer(port uint32, repository Repository) *Server {
+func NewRPCServer(port uint32, repository Repository, network Network) *Server {
 	svr := &Server{
 		Port:       port,
 		Repository: repository,
 		grpcServer: grpc.NewServer(),
+		network:    network,
 	}
 
 	RegisterSwapServiceServer(svr.grpcServer, svr)

--- a/daemon/rpc/server_test.go
+++ b/daemon/rpc/server_test.go
@@ -5,14 +5,14 @@ import (
 )
 
 func TestNewRPCServer(test *testing.T) {
-	server := NewRPCServer(50051, nil)
+	server := NewRPCServer(50051, nil, Network_REGTEST)
 	if server == nil {
 		test.Fatalf("Expected non-nil server")
 	}
 }
 
 func TestListenAndServe(test *testing.T) {
-	server := NewRPCServer(50051, nil)
+	server := NewRPCServer(50051, nil, Network_REGTEST)
 	errChan := make(chan error)
 	go func() {
 		errChan <- server.ListenAndServe()


### PR DESCRIPTION
Introduce network configuration to the server startup process, allowing selection between mainnet, testnet, and regtest environments. Update related RPC server initialization and tests accordingly.