### PR TITLE
Add Docker image build for master and tagged releases

### DIFF
--- a/.github/workflows/daemon.yaml
+++ b/.github/workflows/daemon.yaml
@@ -27,6 +27,8 @@ concurrency:
 
 env:
   GO_VERSION: 1.24.1
+  BASE_BUILDER_IMAGE: golang:1.24.1-alpine
+  BASE_RUNNER_IMAGE: alpine:latest
 
 jobs:
   go-lint:
@@ -74,3 +76,55 @@ jobs:
       - name: Run Tests
         working-directory: daemon
         run: go test ./...
+
+  go-build:
+    # Run this only when we are merging to :master or a new tag is created.
+    if: |
+      github.ref == 'refs/heads/master' ||
+      startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs:
+      - go-lint
+      - go-test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log into the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/40swap
+          labels: |
+            commit=${{ github.sha }}
+            actions_run=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push the Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: daemon/docker
+          file: daemon/docker/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BASE_BUILDER_IMAGE=${{ env.BASE_BUILDER_IMAGE }}
+            BASE_RUNNER_IMAGE=${{ env.BASE_RUNNER_IMAGE }}
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}

--- a/daemon/docker/Dockerfile
+++ b/daemon/docker/Dockerfile
@@ -1,16 +1,16 @@
-ARG BASE_BUILDER_IMAGE=golang:1.24 # This is the alpine-based image for building, e.g. "golang:1.20.4-alpine"
+ARG BASE_BUILDER_IMAGE=golang:1.24.1-alpine # This is the alpine-based image for building, e.g. "golang:1.20.4-alpine"
 ARG BASE_RUNNER_IMAGE=alpine:latest # This is the alpine-based image for running, e.g. "alpine:latest"
 
 FROM ${BASE_BUILDER_IMAGE} AS builder
 COPY . /workspace/
 WORKDIR /workspace/cmd
 
-RUN go build -o 40swap .
+RUN go build -o 40swapd .
 
 FROM ${BASE_RUNNER_IMAGE}
 RUN adduser -D 40swap
 USER 40swap
-WORKDIR /home/ep
-COPY --from=builder /workspace/cmd/40swap /usr/bin/
 
-ENTRYPOINT 40swap
+COPY --from=builder /workspace/cmd/40swapd /usr/bin/
+
+ENTRYPOINT ["/usr/bin/40swapd"]


### PR DESCRIPTION
Implement a GitHub Actions workflow to build and push a Docker image when merging to master or creating a new tag. Update the Dockerfile to reflect changes in the build process and entry point.

Master will be always pushed to <image>:master docker image and tagged release (e.g. 0.0.1) will be <image>:0.0.1