### PR TITLE
Fix 40swapd docker image push and some other CI improvements

### DIFF
--- a/.github/workflows/daemon.yaml
+++ b/.github/workflows/daemon.yaml
@@ -61,9 +61,9 @@ jobs:
 
   build-docker:
     # Run this only when we are merging to :master or a new tag is created.
-    # if: |
-    #   github.ref == 'refs/heads/master' ||
-    #   startsWith(github.ref, 'refs/tags/')
+    if: |
+      github.ref == 'refs/heads/master' ||
+      startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/daemon.yaml
+++ b/.github/workflows/daemon.yaml
@@ -2,14 +2,12 @@ name: Daemon
 
 on:
   workflow_dispatch:
-
   push:
     branches:
       - "master"
     paths:
       - "daemon/**"
       - ".github/workflows/daemon.yaml"
-
     tags:
       - "*"
 
@@ -26,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.24.1
+  REGISTRY: ghcr.io
   BASE_BUILDER_IMAGE: golang:1.24.1-alpine
   BASE_RUNNER_IMAGE: alpine:latest
 
@@ -37,18 +35,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "${{ env.GO_VERSION }}"
-
-      - name: Cache Go modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
+          go-version-file: 'daemon/go.mod'
+          cache-dependency-path: |
+            daemon/go.sum
+            daemon/go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
@@ -61,50 +51,42 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "${{ env.GO_VERSION }}"
-
-      - name: Cache Go modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
+          go-version-file: 'daemon/go.mod'
+          cache-dependency-path: |
+            daemon/go.sum
+            daemon/go.mod
       - name: Run Tests
         working-directory: daemon
         run: go test ./...
 
-  go-build:
+  build-docker:
     # Run this only when we are merging to :master or a new tag is created.
-    if: |
-      github.ref == 'refs/heads/master' ||
-      startsWith(github.ref, 'refs/tags/')
+    # if: |
+    #   github.ref == 'refs/heads/master' ||
+    #   startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     needs:
       - go-lint
       - go-test
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-
       - name: Log into the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/40swap
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/40swapd
           labels: |
             commit=${{ github.sha }}
             actions_run=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -112,7 +94,6 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-
       - name: Build and push the Docker image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,17 +1,33 @@
 name: Backend/Frontend CI
 on:
+  workflow_dispatch:
   push:
-    branches: ["master", "main"]
+    branches:
+      - "master"
     tags:
-      - "**"
+      - "*"
     paths-ignore:
       - "daemon/**"
       - ".justfile"
       - "README.md"
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - "daemon/**"
+      - ".justfile"
+      - "README.md"
+
+concurrency:
+  # Cancel any previous workflows if they are from a PR or push.
+  group: ${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME_FRONTEND: ${{ github.repository }}-swap-frontend
   IMAGE_NAME_BACKEND: ${{ github.repository }}-server-backend
+
 jobs:
   integration-testing:
     runs-on: ubuntu-latest
@@ -25,18 +41,15 @@ jobs:
         volumes:
           - /var/run/docker.sock:/var/run/docker.sock:ro
     steps:
-      - uses: actions/checkout@v3
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.0.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22.x'
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            package.json
       - name: Install dependencies
         working-directory: server-backend
         run: npm ci
@@ -44,51 +57,80 @@ jobs:
         working-directory: server-backend
         run: npm test
   build:
+    # Run this only when we are merging to :master or a new tag is created.
+    if: |
+      github.ref == 'refs/heads/master' ||
+      startsWith(github.ref, 'refs/tags/')
     needs: integration-testing
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.0.0
+      - uses: actions/checkout@v4
+      - name: Log into the Container registry
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract Docker metadata
+      - name: Docker meta
         id: meta-fe
         uses: docker/metadata-action@v5.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_FRONTEND }}
           tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
             type=raw,value={{branch}}-${{github.run_number}}-{{sha}}
             type=raw,value={{branch}}-${{github.run_number}}
+          labels: |
+            commit=${{ github.sha }}
+            actions_run=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
       - name: Build and push frontend Docker image
         id: build-and-push-frontend
         uses: docker/build-push-action@v5.0.0
         with:
           context: .
           file: swap-frontend/docker/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          provenance: false
           tags: ${{ steps.meta-fe.outputs.tags }}
           labels: ${{ steps.meta-fe.outputs.labels }}
-      - name: Extract Docker metadata
+      - name: Docker meta
         id: meta-be
-        uses: docker/metadata-action@v5.0.0
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_BACKEND }}
           tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
             type=raw,value={{branch}}-${{github.run_number}}-{{sha}}
             type=raw,value={{branch}}-${{github.run_number}}
+          labels: |
+            commit=${{ github.sha }}
+            actions_run=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
       - name: Build and push backend Docker image
         id: build-and-push-backend
-        uses: docker/build-push-action@v5.0.0
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: server-backend/docker/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          provenance: false
           tags: ${{ steps.meta-be.outputs.tags }}
           labels: ${{ steps.meta-be.outputs.labels }}

--- a/daemon/docker/Dockerfile
+++ b/daemon/docker/Dockerfile
@@ -13,4 +13,4 @@ USER 40swap
 
 COPY --from=builder /workspace/cmd/40swapd /usr/bin/
 
-ENTRYPOINT ["/usr/bin/40swapd"]
+ENTRYPOINT ["/usr/bin/40swapd", "start"]


### PR DESCRIPTION
This ensures 40swapd docker image can be pushed and introduces some other CI improvements to 40swapd, backend and frontend:

- Run backend integration test in PRs will allow to fix problems before they are merged
- Update Actions dependencies
- Removes cache Action in favor of setup-go and setup-node properly configured to use internal cache action run
- setup-go will load go version from go.mod so we won't need and env here
- concurrency config at backend & frontend CI so new commits to a PR cancel running jobs saving some execution time
- backend and frontend new **extra** tags in a friendlier mode to ArgoCD digest and semver Image Updater modes
- simplify backend and frontend conditionals and removes redundant docker login tasks
