### PR TITLE
Add environment variables  40swapd flags

### DIFF
--- a/daemon/README.md
+++ b/daemon/README.md
@@ -1,2 +1,48 @@
 # 40swapd
 The 40swap daemon (40swapd) interacts with the lightning node to manage the swap process. It features a cli and the daemon itself, the CLI can be used to manually invoke swaps and other configuration operations.
+
+## Configuration
+
+You can configure the 40swap daemon using environment variables or command line arguments. Check the section below or do `40swapd -h` for more information.
+
+## Docs (40swapd -h)
+```
+NAME:
+   40swapd - Manage 40swap daemon and perform swaps
+
+USAGE:
+   40swapd [global options] [command [command options]]
+
+DESCRIPTION:
+   The 40swap daemon supports two database modes:
+     1. Embedded: Uses an embedded PostgreSQL database. This is the default mode and requires no additional configuration. You can specify the following parameters:
+        - db-data-path: Path to the database data directory       
+     2. External: Connects to an external PostgreSQL database. In this mode, you must provide the following parameters:
+        - db-host: Database host
+        - db-user: Database username
+        - db-password: Database password
+        - db-name: Database name
+        - db-port: Database port
+
+COMMANDS:
+   start  Start the 40swapd daemon
+   swap   Swap operations
+   help   Show help
+
+GLOBAL OPTIONS:
+   --db-host value       Database host (default: "embedded") [$40SWAPD_DB_HOST]
+   --db-user value       Database username (default: "40swap") [$40SWAPD_DB_USER]
+   --db-password value   Database password (default: "40swap") [$40SWAPD_DB_PASSWORD]
+   --db-name value       Database name (default: "40swap") [$40SWAPD_DB_NAME]
+   --db-port value       Database port (default: 5433) [$40SWAPD_DB_PORT]
+   --db-data-path value  Database path (NOTE: This is only used for embedded databases) (default: "./.data") [$40SWAPD_DB_DATA_PATH]
+   --db-keep-alive       Keep the database running after the daemon stops for embedded databases (default: false) [$40SWAPD_DB_KEEP_ALIVE]
+   --lndconnect value    LND connect URI (NOTE: This is mutually exclusive with tls-cert, macaroon, and lnd-host) [$40SWAPD_LNDCONNECT]
+   --grpc-port value     Grpc port where the daemon is listening (default: 50051) [$40SWAPD_GRPC_PORT]
+   --server-url value    Server URL (default: "https://app.40swap.com") [$40SWAPD_SERVER_URL]
+   --tls-cert value      TLS certificate file (default: "/root/.lnd/tls.cert") [$40SWAPD_TLS_CERT]
+   --macaroon value      Macaroon file (default: "/root/.lnd/data/chain/bitcoin/mainnet/admin.macaroon") [$40SWAPD_MACAROON]
+   --lnd-host value      LND host (default: "localhost:10009") [$40SWAPD_LND_HOST]
+   --testnet             Use testnet network (default: false) [$40SWAPD_TESTNET]
+   --regtest             Use regtest network (default: false) [$40SWAPD_REGTEST]
+```

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -1,48 +1,6 @@
 # 40swapd
 The 40swap daemon (40swapd) interacts with the lightning node to manage the swap process. It features a cli and the daemon itself, the CLI can be used to manually invoke swaps and other configuration operations.
 
-## Configuration
+## Docs
 
-You can configure the 40swap daemon using environment variables or command line arguments. Check the section below or do `40swapd -h` for more information.
-
-## Docs (40swapd -h)
-```
-NAME:
-   40swapd - Manage 40swap daemon and perform swaps
-
-USAGE:
-   40swapd [global options] [command [command options]]
-
-DESCRIPTION:
-   The 40swap daemon supports two database modes:
-     1. Embedded: Uses an embedded PostgreSQL database. This is the default mode and requires no additional configuration. You can specify the following parameters:
-        - db-data-path: Path to the database data directory       
-     2. External: Connects to an external PostgreSQL database. In this mode, you must provide the following parameters:
-        - db-host: Database host
-        - db-user: Database username
-        - db-password: Database password
-        - db-name: Database name
-        - db-port: Database port
-
-COMMANDS:
-   start  Start the 40swapd daemon
-   swap   Swap operations
-   help   Show help
-
-GLOBAL OPTIONS:
-   --db-host value       Database host (default: "embedded") [$40SWAPD_DB_HOST]
-   --db-user value       Database username (default: "40swap") [$40SWAPD_DB_USER]
-   --db-password value   Database password (default: "40swap") [$40SWAPD_DB_PASSWORD]
-   --db-name value       Database name (default: "40swap") [$40SWAPD_DB_NAME]
-   --db-port value       Database port (default: 5433) [$40SWAPD_DB_PORT]
-   --db-data-path value  Database path (NOTE: This is only used for embedded databases) (default: "./.data") [$40SWAPD_DB_DATA_PATH]
-   --db-keep-alive       Keep the database running after the daemon stops for embedded databases (default: false) [$40SWAPD_DB_KEEP_ALIVE]
-   --lndconnect value    LND connect URI (NOTE: This is mutually exclusive with tls-cert, macaroon, and lnd-host) [$40SWAPD_LNDCONNECT]
-   --grpc-port value     Grpc port where the daemon is listening (default: 50051) [$40SWAPD_GRPC_PORT]
-   --server-url value    Server URL (default: "https://app.40swap.com") [$40SWAPD_SERVER_URL]
-   --tls-cert value      TLS certificate file (default: "/root/.lnd/tls.cert") [$40SWAPD_TLS_CERT]
-   --macaroon value      Macaroon file (default: "/root/.lnd/data/chain/bitcoin/mainnet/admin.macaroon") [$40SWAPD_MACAROON]
-   --lnd-host value      LND host (default: "localhost:10009") [$40SWAPD_LND_HOST]
-   --testnet             Use testnet network (default: false) [$40SWAPD_TESTNET]
-   --regtest             Use regtest network (default: false) [$40SWAPD_REGTEST]
-```
+You can configure the 40swap daemon using environment variables or command line arguments. Check `40swapd -h` for more information.

--- a/daemon/cmd/main.go
+++ b/daemon/cmd/main.go
@@ -46,8 +46,17 @@ func main() {
 	}()
 
 	app := &cli.Command{
-		Name:  "40swap",
-		Usage: "A CLI for 40swap daemon",
+		Name:  "40swapd",
+		Usage: "Manage 40swap daemon and perform swaps",
+		Description: `The 40swap daemon supports two database modes:
+  1. Embedded: Uses an embedded PostgreSQL database. This is the default mode and requires no additional configuration. You can specify the following parameters:
+	   - db-data-path: Path to the database data directory 			
+  2. External: Connects to an external PostgreSQL database. In this mode, you must provide the following parameters:
+     - db-host: Database host
+     - db-user: Database username
+     - db-password: Database password
+     - db-name: Database name
+     - db-port: Database port`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "db-host",
@@ -86,7 +95,7 @@ func main() {
 			},
 			&cli.StringFlag{
 				Name:  "db-data-path",
-				Usage: "Database path",
+				Usage: "Database path (NOTE: This is only used for embedded databases)",
 				Value: "./.data",
 				Sources: cli.NewValueSourceChain(
 					cli.EnvVar("40SWAPD_DB_DATA_PATH")),

--- a/daemon/cmd/main.go
+++ b/daemon/cmd/main.go
@@ -53,48 +53,90 @@ func main() {
 				Name:  "db-host",
 				Usage: "Database host",
 				Value: "embedded",
+				Sources: cli.NewValueSourceChain(
+					cli.EnvVar("40SWAPD_DB_HOST")),
 			},
 			&cli.StringFlag{
 				Name:  "db-user",
 				Usage: "Database username",
 				Value: "40swap",
+				Sources: cli.NewValueSourceChain(
+					cli.EnvVar("40SWAPD_DB_USER")),
 			},
 			&cli.StringFlag{
 				Name:  "db-password",
 				Usage: "Database password",
 				Value: "40swap",
+				Sources: cli.NewValueSourceChain(
+					cli.EnvVar("40SWAPD_DB_PASSWORD")),
 			},
 			&cli.StringFlag{
 				Name:  "db-name",
 				Usage: "Database name",
 				Value: "40swap",
+				Sources: cli.NewValueSourceChain(
+					cli.EnvVar("40SWAPD_DB_NAME")),
 			},
 			&cli.IntFlag{
 				Name:  "db-port",
 				Usage: "Database port",
 				Value: 5433,
+				Sources: cli.NewValueSourceChain(
+					cli.EnvVar("40SWAPD_DB_PORT")),
 			},
 			&cli.StringFlag{
 				Name:  "db-data-path",
 				Usage: "Database path",
 				Value: "./.data",
+				Sources: cli.NewValueSourceChain(
+					cli.EnvVar("40SWAPD_DB_DATA_PATH")),
 			},
 			&cli.BoolFlag{
 				Name:  "db-keep-alive",
 				Usage: "Keep the database running after the daemon stops for embedded databases",
 				Value: false,
+				Sources: cli.NewValueSourceChain(
+					cli.EnvVar("40SWAPD_DB_KEEP_ALIVE")),
 			},
 			&cli.StringFlag{
 				Name:  "lndconnect",
-				Usage: "LND connect URI",
+				Usage: "LND connect URI (NOTE: This is mutually exclusive with tls-cert, macaroon, and lnd-host)",
+				Sources: cli.NewValueSourceChain(
+					cli.EnvVar("40SWAPD_LNDCONNECT")),
 			},
-			&grpcPort,
-			&serverUrl,
-			&tlsCert,
-			&macaroon,
-			&lndHost,
-			&testnet,
-			&regtest,
+			&cli.StringFlag{
+				Name:  "tls-cert",
+				Usage: "TLS certificate file",
+				Value: "/root/.lnd/tls.cert",
+				Sources: cli.NewValueSourceChain(
+					cli.EnvVar("40SWAPD_TLS_CERT")),
+			},
+			&cli.StringFlag{
+				Name:  "macaroon",
+				Usage: "Macaroon file",
+				Value: "/root/.lnd/data/chain/bitcoin/mainnet/admin.macaroon",
+				Sources: cli.NewValueSourceChain(
+					cli.EnvVar("40SWAPD_MACAROON")),
+			},
+			&cli.StringFlag{
+				Name:  "lnd-host",
+				Usage: "LND host",
+				Value: "localhost:10009",
+				Sources: cli.NewValueSourceChain(
+					cli.EnvVar("40SWAPD_LND_HOST")),
+			},
+			&cli.BoolFlag{
+				Name:  "testnet",
+				Usage: "Use testnet network",
+				Sources: cli.NewValueSourceChain(
+					cli.EnvVar("40SWAPD_TESTNET")),
+			},
+			&cli.BoolFlag{
+				Name:  "regtest",
+				Usage: "Use regtest network",
+				Sources: cli.NewValueSourceChain(
+					cli.EnvVar("40SWAPD_REGTEST")),
+			},
 		},
 		Commands: []*cli.Command{
 			{
@@ -384,10 +426,14 @@ func main() {
 var regtest = cli.BoolFlag{
 	Name:  "regtest",
 	Usage: "Use regtest network",
+	Sources: cli.NewValueSourceChain(
+		cli.EnvVar("40SWAPD_REGTEST")),
 }
 var testnet = cli.BoolFlag{
 	Name:  "testnet",
 	Usage: "Use testnet network",
+	Sources: cli.NewValueSourceChain(
+		cli.EnvVar("40SWAPD_TESTNET")),
 }
 
 // Chains
@@ -403,8 +449,10 @@ var liquid = cli.BoolFlag{
 // Ports and hosts
 var grpcPort = cli.IntFlag{
 	Name:  "grpc-port",
-	Usage: "Grpc port for client to daemon communication",
+	Usage: "Grpc port where the daemon is listening",
 	Value: 50051,
+	Sources: cli.NewValueSourceChain(
+		cli.EnvVar("40SWAPD_GRPC_PORT")),
 }
 var amountSats = cli.UintFlag{
 	Name:     "amt",
@@ -422,6 +470,8 @@ var serverUrl = cli.StringFlag{
 	Name:  "server-url",
 	Usage: "Server URL",
 	Value: "https://app.40swap.com",
+	Sources: cli.NewValueSourceChain(
+		cli.EnvVar("40SWAPD_SERVER_URL")),
 }
 
 // config files
@@ -429,14 +479,20 @@ var tlsCert = cli.StringFlag{
 	Name:  "tls-cert",
 	Usage: "TLS certificate file",
 	Value: "/root/.lnd/tls.cert",
+	Sources: cli.NewValueSourceChain(
+		cli.EnvVar("40SWAPD_TLS_CERT")),
 }
 var macaroon = cli.StringFlag{
 	Name:  "macaroon",
 	Usage: "Macaroon file",
 	Value: "/root/.lnd/data/chain/bitcoin/mainnet/admin.macaroon",
+	Sources: cli.NewValueSourceChain(
+		cli.EnvVar("40SWAPD_MACAROON")),
 }
 var lndHost = cli.StringFlag{
 	Name:  "lnd-host",
 	Usage: "LND host",
 	Value: "localhost:10009",
+	Sources: cli.NewValueSourceChain(
+		cli.EnvVar("40SWAPD_LND_HOST")),
 }

--- a/daemon/cmd/main.go
+++ b/daemon/cmd/main.go
@@ -104,39 +104,13 @@ func main() {
 				Sources: cli.NewValueSourceChain(
 					cli.EnvVar("40SWAPD_LNDCONNECT")),
 			},
-			&cli.StringFlag{
-				Name:  "tls-cert",
-				Usage: "TLS certificate file",
-				Value: "/root/.lnd/tls.cert",
-				Sources: cli.NewValueSourceChain(
-					cli.EnvVar("40SWAPD_TLS_CERT")),
-			},
-			&cli.StringFlag{
-				Name:  "macaroon",
-				Usage: "Macaroon file",
-				Value: "/root/.lnd/data/chain/bitcoin/mainnet/admin.macaroon",
-				Sources: cli.NewValueSourceChain(
-					cli.EnvVar("40SWAPD_MACAROON")),
-			},
-			&cli.StringFlag{
-				Name:  "lnd-host",
-				Usage: "LND host",
-				Value: "localhost:10009",
-				Sources: cli.NewValueSourceChain(
-					cli.EnvVar("40SWAPD_LND_HOST")),
-			},
-			&cli.BoolFlag{
-				Name:  "testnet",
-				Usage: "Use testnet network",
-				Sources: cli.NewValueSourceChain(
-					cli.EnvVar("40SWAPD_TESTNET")),
-			},
-			&cli.BoolFlag{
-				Name:  "regtest",
-				Usage: "Use regtest network",
-				Sources: cli.NewValueSourceChain(
-					cli.EnvVar("40SWAPD_REGTEST")),
-			},
+			&grpcPort,
+			&serverUrl,
+			&tlsCert,
+			&macaroon,
+			&lndHost,
+			&testnet,
+			&regtest,
 		},
 		Commands: []*cli.Command{
 			{


### PR DESCRIPTION
Introduce environment variable support for various CLI flags in the 40swapd application. Additionally, provide clearer usage notes for certain flags.