### PR TITLE
Set refund flag to optional

### DIFF
--- a/daemon/cmd/main.go
+++ b/daemon/cmd/main.go
@@ -195,11 +195,9 @@ func main() {
 								Aliases: []string{"e"},
 							},
 							&cli.StringFlag{
-								Name: "refund-to",
-								// TODO descriptor and xpub
-								Usage:    "The address where the swap will be refunded to",
-								Aliases:  []string{"r"},
-								Required: true,
+								Name:    "refund-to",
+								Usage:   "The address where the swap will be refunded to",
+								Aliases: []string{"r"},
 							},
 							&amountSats,
 							&grpcPort,

--- a/daemon/lightning/lightning.go
+++ b/daemon/lightning/lightning.go
@@ -26,4 +26,5 @@ type Client interface {
 	MonitorPaymentRequest(ctx context.Context, paymentHash string) (Preimage, NetworkFeeSats, error)
 	MonitorPaymentReception(ctx context.Context, rhash []byte) (Preimage, error)
 	GenerateInvoice(ctx context.Context, amountSats decimal.Decimal, expiry time.Duration, memo string) (paymentRequest string, rhash []byte, e error)
+	GenerateAddress(ctx context.Context) (string, error)
 }

--- a/daemon/lightning/lnd/lnd.go
+++ b/daemon/lightning/lnd/lnd.go
@@ -87,8 +87,8 @@ var (
 
 var ErrMutuallyExclusiveOptions = errors.New("LNDConnect is mutually exclusive with filesystem-level credentials")
 
-// NewClient creates a lnd client from a daprlndconnectURI string.
-// This Client establishes a grpc connection with a lnd node using dapr.
+// NewClient creates a lnd client from a lndconnectURI string.
+// This Client establishes a grpc connection with a lnd node using grpc.
 // It is using two stubs: router and ln.
 func NewClient(ctx context.Context, opts ...Option) (*Client, error) {
 	// Default options
@@ -218,9 +218,9 @@ func credentialsFromCertString(certDer string) (credentials.TransportCredentials
 }
 
 // PayInvoice uses the lnd node to pay the invoice provided by the paymentRequest
-func (dc *Client) PayInvoice(ctx context.Context, paymentRequest string, feeLimitRatio float64) error {
+func (c *Client) PayInvoice(ctx context.Context, paymentRequest string, feeLimitRatio float64) error {
 	// Decode payment request
-	payReq, err := dc.lndClient.DecodePayReq(ctx, &lnrpc.PayReqString{PayReq: paymentRequest})
+	payReq, err := c.lndClient.DecodePayReq(ctx, &lnrpc.PayReqString{PayReq: paymentRequest})
 	if err != nil {
 		err = fmt.Errorf("error decoding payment request: %w", err)
 
@@ -236,7 +236,7 @@ func (dc *Client) PayInvoice(ctx context.Context, paymentRequest string, feeLimi
 		TimeoutSeconds: int32((time.Minute * 5).Seconds()),
 	}
 
-	stream, err := dc.routerClient.SendPaymentV2(ctx, sendRequest)
+	stream, err := c.routerClient.SendPaymentV2(ctx, sendRequest)
 	if err != nil {
 		return err
 	}
@@ -259,7 +259,7 @@ func (dc *Client) PayInvoice(ctx context.Context, paymentRequest string, feeLimi
 }
 
 // MonitorPaymentRequest monitors a payment to know its status
-func (dc *Client) MonitorPaymentRequest(ctx context.Context, paymentHash string) (lightning.Preimage, lightning.NetworkFeeSats, error) {
+func (c *Client) MonitorPaymentRequest(ctx context.Context, paymentHash string) (lightning.Preimage, lightning.NetworkFeeSats, error) {
 	hash, err := hex.DecodeString(paymentHash)
 	if err != nil {
 		return "", 0, err
@@ -269,7 +269,7 @@ func (dc *Client) MonitorPaymentRequest(ctx context.Context, paymentHash string)
 		PaymentHash: hash,
 	}
 
-	stream, err := dc.routerClient.TrackPaymentV2(ctx, monitorRequest)
+	stream, err := c.routerClient.TrackPaymentV2(ctx, monitorRequest)
 	if err != nil {
 		return "", 0, err
 	}
@@ -311,11 +311,11 @@ func checkContextDeadline(err error, prefix string) error {
 	return fmt.Errorf("%s: %w", prefix, err)
 }
 
-func (dc *Client) MonitorPaymentReception(ctx context.Context, rhash []byte) (lightning.Preimage, error) {
+func (c *Client) MonitorPaymentReception(ctx context.Context, rhash []byte) (lightning.Preimage, error) {
 	invoiceSubscription := &invoicesrpc.SubscribeSingleInvoiceRequest{
 		RHash: rhash,
 	}
-	stream, err := dc.invoicesClient.SubscribeSingleInvoice(ctx, invoiceSubscription)
+	stream, err := c.invoicesClient.SubscribeSingleInvoice(ctx, invoiceSubscription)
 	if err != nil {
 		return "", checkContextDeadline(err, "subscribing to invoice")
 	}
@@ -342,7 +342,7 @@ func (dc *Client) MonitorPaymentReception(ctx context.Context, rhash []byte) (li
 	}
 }
 
-func (dc *Client) GenerateInvoice(ctx context.Context, amountSats decimal.Decimal, expiry time.Duration, memo string) (paymentRequest string, rhash []byte, e error) {
+func (c *Client) GenerateInvoice(ctx context.Context, amountSats decimal.Decimal, expiry time.Duration, memo string) (paymentRequest string, rhash []byte, e error) {
 	invoiceReq := &lnrpc.Invoice{
 		Value:           amountSats.IntPart(),
 		Memo:            memo,
@@ -352,7 +352,7 @@ func (dc *Client) GenerateInvoice(ctx context.Context, amountSats decimal.Decima
 		DescriptionHash: nil,                         // Optional description hash
 	}
 
-	res, err := dc.lndClient.AddInvoice(ctx, invoiceReq)
+	res, err := c.lndClient.AddInvoice(ctx, invoiceReq)
 	if err != nil {
 		return "", nil, err
 	}
@@ -360,9 +360,20 @@ func (dc *Client) GenerateInvoice(ctx context.Context, amountSats decimal.Decima
 	return res.PaymentRequest, res.RHash, nil
 }
 
+func (c *Client) GenerateAddress(ctx context.Context) (string, error) {
+	res, err := c.lndClient.NewAddress(ctx, &lnrpc.NewAddressRequest{
+		Type: lnrpc.AddressType_UNUSED_WITNESS_PUBKEY_HASH,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return res.Address, nil
+}
+
 // CloseConnection closes the connection with the lnd node
-func (dc *Client) CloseConnection() {
-	dc.closeConnection()
+func (c *Client) CloseConnection() {
+	c.closeConnection()
 }
 
 // Generates the gRPC router client

--- a/daemon/lightning/lnd/lnd.go
+++ b/daemon/lightning/lnd/lnd.go
@@ -360,6 +360,7 @@ func (c *Client) GenerateInvoice(ctx context.Context, amountSats decimal.Decimal
 }
 
 func (c *Client) GenerateAddress(ctx context.Context) (string, error) {
+	// TODO: Add a parameter to this method to generate other types of addresses
 	res, err := c.lndClient.NewAddress(ctx, &lnrpc.NewAddressRequest{
 		Type: lnrpc.AddressType_UNUSED_WITNESS_PUBKEY_HASH,
 	})

--- a/daemon/lightning/lnd/lnd.go
+++ b/daemon/lightning/lnd/lnd.go
@@ -87,9 +87,8 @@ var (
 
 var ErrMutuallyExclusiveOptions = errors.New("LNDConnect is mutually exclusive with filesystem-level credentials")
 
-// NewClient creates a lnd client from a lndconnectURI string.
+// NewClient creates a lnd client from a lndconnectURI string or macaroon and cert file locations.
 // This Client establishes a grpc connection with a lnd node using grpc.
-// It is using two stubs: router and ln.
 func NewClient(ctx context.Context, opts ...Option) (*Client, error) {
 	// Default options
 	options := Options{

--- a/daemon/lightning/mock.go
+++ b/daemon/lightning/mock.go
@@ -42,6 +42,21 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// GenerateAddress mocks base method.
+func (m *MockClient) GenerateAddress(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GenerateAddress", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GenerateAddress indicates an expected call of GenerateAddress.
+func (mr *MockClientMockRecorder) GenerateAddress(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateAddress", reflect.TypeOf((*MockClient)(nil).GenerateAddress), ctx)
+}
+
 // GenerateInvoice mocks base method.
 func (m *MockClient) GenerateInvoice(ctx context.Context, amountSats decimal.Decimal, expiry time.Duration, memo string) (string, []byte, error) {
 	m.ctrl.T.Helper()

--- a/daemon/rpc/handlers.go
+++ b/daemon/rpc/handlers.go
@@ -53,9 +53,16 @@ func (server *Server) SwapIn(ctx context.Context, req *SwapInRequest) (*SwapInRe
 		return nil, fmt.Errorf("invalid invoice: %w", err)
 	}
 
+	// If the user didn't provide a refund address, generate one to the connected lightning node
 	if req.RefundTo == "" {
-		return nil, fmt.Errorf("refund address is required")
+		address, err := server.lightningClient.GenerateAddress(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("could not generate address: %w", err)
+		}
+
+		req.RefundTo = address
 	}
+
 	address, err := btcutil.DecodeAddress(req.RefundTo, lightning.ToChainCfgNetwork(network))
 	if err != nil {
 		return nil, fmt.Errorf("invalid refund address: %w", err)


### PR DESCRIPTION
This pull requests sets the refund flag as optional in the cli, and if empty it will ask LND for an unused address so the refund can be don to LNDs wallet