### PR TITLE
Swap out runner for liquid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4852,6 +4852,59 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/bip32": {
+      "version": "5.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-5.0.0-rc.0.tgz",
+      "integrity": "sha512-5hVFGrdCnF8GB1Lj2eEo4PRE7+jp+3xBLnfNjydivOkMvKmUKeJ9GG8uOy8prmWl3Oh154uzgfudR1FRkNBudA==",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "@scure/base": "^1.1.1",
+        "uint8array-tools": "^0.0.8",
+        "valibot": "^0.37.0",
+        "wif": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/bip32/node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="
+    },
+    "node_modules/bip32/node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
+    },
+    "node_modules/bip32/node_modules/bs58check": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "bs58": "^6.0.0"
+      }
+    },
+    "node_modules/bip32/node_modules/uint8array-tools": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.8.tgz",
+      "integrity": "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/bip32/node_modules/wif": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-5.0.0.tgz",
+      "integrity": "sha512-iFzrC/9ne740qFbNjTZ2FciSRJlHIXoxqk/Y5EnE08QOXu1WjJyCCswwDTYbohAOEnlCtLaAAQBhyaLRFh2hMA==",
+      "dependencies": {
+        "bs58check": "^4.0.0"
+      }
+    },
     "node_modules/bip66": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
@@ -12548,7 +12601,7 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
       "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12704,6 +12757,19 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.37.0.tgz",
+      "integrity": "sha512-FQz52I8RXgFgOHym3XHYSREbNtkgSjF9prvMFH1nBsRyfL6SfCzoT1GuSDTlbsuPubM7/6Kbw0ZMQb8A+V+VsQ==",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/validate-html-nesting": {
@@ -13496,6 +13562,7 @@
         "@nestjs/typeorm": "^10.0.2",
         "@scure/bip32": "^1.6.2",
         "@vulpemventures/secp256k1-zkp": "^3.2.1",
+        "bip32": "^5.0.0-rc.0",
         "bitcoinjs-lib": "6.1.6",
         "bolt11": "^1.4.1",
         "decimal.js": "^10.4.3",

--- a/server-backend/package.json
+++ b/server-backend/package.json
@@ -35,6 +35,7 @@
     "@nestjs/typeorm": "^10.0.2",
     "@scure/bip32": "^1.6.2",
     "@vulpemventures/secp256k1-zkp": "^3.2.1",
+    "bip32": "^5.0.0-rc.0",
     "bitcoinjs-lib": "6.1.6",
     "bolt11": "^1.4.1",
     "decimal.js": "^10.4.3",

--- a/server-backend/src/LiquidUtils.ts
+++ b/server-backend/src/LiquidUtils.ts
@@ -27,34 +27,6 @@ export function getLiquidNetwork(network: bitcoinNetwork): liquidNetwork {
     }
 }
 
-export function liquidReverseSwapScript(
-    preimageHash: Buffer,
-    claimPublicKey: Buffer,
-    refundPublicKey: Buffer,
-    timeoutBlockHeight: number,
-): Buffer {
-    /* eslint-disable indent */
-    const htlcScript = liquid.script.compile([
-        liquid.script.OPS.OP_SIZE,
-        liquid.script.number.encode(32),
-        liquid.script.OPS.OP_EQUAL,
-        liquid.script.OPS.OP_IF,
-            liquid.script.OPS.OP_HASH160,
-            liquid.crypto.ripemd160(preimageHash),
-            liquid.script.OPS.OP_EQUALVERIFY,
-            claimPublicKey,
-        liquid.script.OPS.OP_ELSE,
-            liquid.script.OPS.OP_DROP,
-            liquid.script.number.encode(timeoutBlockHeight),
-            liquid.script.OPS.OP_CHECKLOCKTIMEVERIFY,
-            liquid.script.OPS.OP_DROP,
-            refundPublicKey,
-        liquid.script.OPS.OP_ENDIF,
-        liquid.script.OPS.OP_CHECKSIG,
-    ]);
-    return htlcScript;
-}
-
 export function getLiquidNumber(amount: number): number {
     return liquid.ElementsValue.fromNumber(amount).number;
 }

--- a/server-backend/src/LiquidUtils.ts
+++ b/server-backend/src/LiquidUtils.ts
@@ -1,5 +1,17 @@
-import { liquid as liquidMainnet, regtest as liquidRegtest, testnet as liquidTestnet, Network as liquidNetwork } from 'liquidjs-lib/src/networks.js';
 import { bitcoin as bitcoinMainnet, regtest as bitcoinRegtest, testnet as bitcoinTestnet, Network as bitcoinNetwork } from 'bitcoinjs-lib/src/networks.js';
+import { liquid as liquidMainnet, regtest as liquidRegtest, testnet as liquidTestnet, Network as liquidNetwork } from 'liquidjs-lib/src/networks.js';
+import { LiquidService, RPCUtxo } from './LiquidService.js';
+import { FourtySwapConfiguration } from './configuration';
+import { ECPairFactory, ECPairInterface } from 'ecpair';
+import { NbxplorerService } from './NbxplorerService';
+import { SwapOut } from './entities/SwapOut';
+import * as liquid from 'liquidjs-lib';
+import * as ecc from 'tiny-secp256k1';
+import assert from 'node:assert';
+import BIP32Factory from 'bip32';
+
+const bip32 = BIP32Factory(ecc);
+const ECPair = ECPairFactory(ecc);
 
 
 export function getLiquidNetwork(network: bitcoinNetwork): liquidNetwork {
@@ -12,5 +24,304 @@ export function getLiquidNetwork(network: bitcoinNetwork): liquidNetwork {
         return liquidTestnet;
     default:
         throw new Error(`Unsupported network: ${network}`);
+    }
+}
+
+export function liquidReverseSwapScript(
+    preimageHash: Buffer,
+    claimPublicKey: Buffer,
+    refundPublicKey: Buffer,
+    timeoutBlockHeight: number,
+): Buffer {
+    /* eslint-disable indent */
+    const htlcScript = liquid.script.compile([
+        liquid.script.OPS.OP_SIZE,
+        liquid.script.number.encode(32),
+        liquid.script.OPS.OP_EQUAL,
+        liquid.script.OPS.OP_IF,
+            liquid.script.OPS.OP_HASH160,
+            liquid.crypto.ripemd160(preimageHash),
+            liquid.script.OPS.OP_EQUALVERIFY,
+            claimPublicKey,
+        liquid.script.OPS.OP_ELSE,
+            liquid.script.OPS.OP_DROP,
+            liquid.script.number.encode(timeoutBlockHeight),
+            liquid.script.OPS.OP_CHECKLOCKTIMEVERIFY,
+            liquid.script.OPS.OP_DROP,
+            refundPublicKey,
+        liquid.script.OPS.OP_ENDIF,
+        liquid.script.OPS.OP_CHECKSIG,
+    ]);
+    return htlcScript;
+}
+
+export function getLiquidNumber(amount: number): number {
+    return liquid.ElementsValue.fromNumber(amount).number;
+}
+
+export function getRelativePathFromDescriptor(descriptor: string): string {
+    // eg input: wpkh([53b1e541/84'/1'/0'/0/12]02620eb1f212038380c0b169401d2b1ba6b440ca34b006758b921727d26fb3085c)#xac9tzr5
+    // eg output: 0/12
+    const match = descriptor.match(/\/\d+'\/\d+'\/\d'\/(\d+\/\d+)\]/);
+    if (!match) {
+        throw new Error('Invalid descriptor format');
+    }
+    return match[1];
+}
+
+
+export abstract class LiquidPSETBuilder {
+    public signatures: Buffer[] = [];
+    protected liquidService: LiquidService;
+    protected signingKeys: ECPairInterface[] = [];
+    protected network: liquid.networks.Network;
+
+    public readonly lockSequence = 0xffffffff;
+    public readonly refundSequence = 0xfffffffe;
+
+    constructor(
+        protected nbxplorer: NbxplorerService,
+        protected elementsConfig: FourtySwapConfiguration['elements'],
+        network: liquid.networks.Network,
+    ) {
+        this.network = network;
+        this.liquidService = new LiquidService(nbxplorer, elementsConfig);
+    }
+
+    abstract getPset(...args: unknown[]): Promise<liquid.Pset>;
+
+    async getCommissionAmount(): Promise<number> {
+        const mempoolInfo = await this.liquidService.getMempoolInfo();
+        return mempoolInfo.minrelaytxfee * 1e8;
+    }
+
+    addInput(pset: liquid.Pset, txId: string, inputIndex: number,  sequence: number): void {
+        const input = new liquid.CreatorInput(txId, inputIndex, sequence);
+        pset.addInput(input.toPartialInput());
+    }
+
+    addOutput(
+        updater: liquid.Updater, amount: number, script?: Buffer | undefined, blindingKey?: Buffer | undefined
+    ): void {
+        const changeOutput = new liquid.CreatorOutput(
+            this.network.assetHash,
+            amount,
+            script ?? undefined,
+            // TODO: Add blinding key
+            // blindingKey !== undefined ? blindingKey : undefined,
+        );
+        updater.addOutputs([changeOutput]);
+    }
+
+    signIndex(
+        pset: liquid.Pset, 
+        signer: liquid.Signer, 
+        signingKeyPair: ECPairInterface, 
+        index: number, 
+        sigHashType: number = liquid.Transaction.SIGHASH_ALL
+    ): Buffer {
+        const signature = liquid.script.signature.encode(
+            signingKeyPair.sign(pset.getInputPreimage(index, sigHashType)),
+            sigHashType
+        );
+        signer.addSignature(
+            index,
+            {
+                partialSig: {
+                    pubkey: signingKeyPair.publicKey,
+                    signature,
+                },
+            },
+            liquid.Pset.ECDSASigValidator(ecc),
+        );
+        return signature;
+    }
+
+    finalizeIndexWithStack(finalizer: liquid.Finalizer, index: number, stack: Buffer[]): void {
+        finalizer.finalizeInput(index, () => {
+            const finalScriptWitness = liquid.witnessStackToScriptWitness(stack);
+            return {finalScriptWitness};
+        });
+    }
+}
+
+export class LiquidLockPSETBuilder extends LiquidPSETBuilder {
+
+    async getPset(
+        amount: number, 
+        contractAddress: string, 
+        blindingKey: Buffer, 
+        timeoutBlockHeight: number
+    ): Promise<liquid.Pset> {
+        const commision = await this.getCommissionAmount();
+        const totalAmount = amount + commision;
+        const { utxos, totalInputValue } = await this.liquidService.getConfirmedUtxosAndInputValueForAmount(totalAmount);
+
+        // Create a new pset
+        const pset = liquid.Creator.newPset({locktime: timeoutBlockHeight});
+        const updater = new liquid.Updater(pset);
+
+        // Add inputs to pset
+        await this.addInputs(utxos, pset, updater);
+
+        // Add required outputs (claim, change, fee) to pset
+        await this.addRequiredOutputs(amount, totalInputValue, commision, updater, contractAddress, blindingKey);
+
+        // TODO: Blind pset
+        // await this.blindPset(utxos, pset, blindingKey);
+
+        return pset;
+    }
+
+    async addInputs(utxos: RPCUtxo[], pset: liquid.Pset, updater: liquid.Updater): Promise<void> {
+        await Promise.all(utxos.map(async (utxo, i) => {
+            const liquidTx = await this.liquidService.getUtxoTx(utxo, this.liquidService.xpub);
+            const witnessUtxo = liquidTx.outs[utxo.vout];
+            this.addInput(pset, liquidTx.getId(), utxo.vout, this.lockSequence);
+            updater.addInSighashType(i, liquid.Transaction.SIGHASH_ALL);
+            updater.addInWitnessUtxo(i, witnessUtxo);
+            const relativePath = getRelativePathFromDescriptor(utxo.desc);
+            try {
+                const node = bip32.fromBase58(this.liquidService.xpub, this.network);
+                const childNode = node.derivePath(relativePath);
+                updater.addInBIP32Derivation(i, {
+                    masterFingerprint: Buffer.from(node.fingerprint),
+                    pubkey: Buffer.from(childNode.publicKey),
+                    path: relativePath,
+                });
+            } catch (error) {
+                throw new Error(`Failed to derive path ${relativePath}: ${error}`);
+            }
+        })).catch((error) => {
+            throw new Error(`Error adding inputs: ${error}`);
+        });
+    }
+    
+    async addRequiredOutputs(
+        amount: number,
+        totalInputValue: number,
+        commision: number,
+        updater: liquid.Updater,
+        contractAddress: string,
+        blindingKey?: Buffer | undefined,
+    ): Promise<void> {
+        // Add claim output to pset
+        const claimOutputScript = liquid.address.toOutputScript(contractAddress, this.network);
+        this.addOutput(updater, getLiquidNumber(amount), claimOutputScript, blindingKey);
+
+        // Add change output to pset
+        const changeAddress = await this.liquidService.getNewAddress();
+        const changeOutputScript = liquid.address.toOutputScript(changeAddress, this.network);
+        const changeAmount = getLiquidNumber(totalInputValue - amount - commision);
+        this.addOutput(updater, changeAmount, changeOutputScript, blindingKey);
+
+        // Add fee output to pset
+        const feeAmount = getLiquidNumber(commision);
+        this.addOutput(updater, feeAmount);
+    }
+
+    async getTx(pset: liquid.Pset): Promise<liquid.Transaction> {
+        const signedPset = await this.liquidService.signPset(pset.toBase64());
+        const finalizedPsetHex = await this.liquidService.getFinalizedPsetHex(signedPset.toBase64());
+        const transaction = liquid.Transaction.fromHex(finalizedPsetHex);
+        return transaction;
+    }
+}
+
+export class LiquidRefundPSETBuilder extends LiquidPSETBuilder {
+
+    async getPset(swap: SwapOut, spendingTx: liquid.Transaction): Promise<liquid.Pset> {
+        // Find the contract vout info
+        const { contractOutputIndex, outputValue, witnessUtxo } = this.getContractVoutInfo(
+            spendingTx, swap.contractAddress!, this.network
+        );
+        
+        // Create a new pset
+        const pset = liquid.Creator.newPset({
+            locktime: swap.timeoutBlockHeight,
+        });
+        const updater = new liquid.Updater(pset);
+        const psetInputIndex = 0;
+        
+        // Add input
+        this.addRefundInput(pset, updater, psetInputIndex, spendingTx, contractOutputIndex, witnessUtxo, swap);
+
+        // Add required outputs
+        await this.addRequiredOutputs(swap, updater, outputValue);
+        
+        // Sign pset inputs
+        const signer = new liquid.Signer(pset);
+        const signingKeyPair = ECPair.fromPrivateKey(swap.unlockPrivKey);
+        const signature = this.signIndex(pset, signer, signingKeyPair, psetInputIndex, liquid.Transaction.SIGHASH_ALL);
+
+        // Finalize pset
+        const finalizer = new liquid.Finalizer(pset);
+        const stack = [signature, Buffer.from(''), pset.inputs[psetInputIndex].witnessScript!];
+        this.finalizeIndexWithStack(finalizer, psetInputIndex, stack);
+        return pset;
+    }
+
+    addRefundInput(
+        pset: liquid.Pset, 
+        updater: liquid.Updater, 
+        psetInputIndex: number,
+        spendingTx: liquid.Transaction, 
+        contractOutputIndex: number, 
+        witnessUtxo: liquid.TxOutput, 
+        swap: SwapOut
+    ): void {
+        this.addInput(pset, spendingTx.getId(), contractOutputIndex, this.refundSequence);
+        updater.addInSighashType(psetInputIndex, liquid.Transaction.SIGHASH_ALL);
+        updater.addInWitnessUtxo(psetInputIndex, witnessUtxo);
+        updater.addInWitnessScript(psetInputIndex, swap.lockScript!);
+    }
+
+    async addRequiredOutputs(swap: SwapOut, updater: liquid.Updater, outputValue: number): Promise<void> {
+        // Calculate output amount and fee
+        const feeAmount = await this.getCommissionAmount();
+        const outputAmount = outputValue - feeAmount;
+        
+        // Add output
+        const outputScript = liquid.address.toOutputScript(swap.sweepAddress!, this.network);
+        this.addOutput(updater, outputAmount, outputScript);
+        
+        // Add fee output - required for Liquid
+        this.addOutput(updater, feeAmount);
+    }
+
+    getContractVoutInfo(
+        spendingTx: liquid.Transaction, contractAddress: string, network: liquid.networks.Network
+    ): {
+        contractOutputIndex: number;
+        outputValue: number;
+        witnessUtxo: liquid.TxOutput;
+    } {
+        let outputValue = 0;
+        let contractOutputIndex = -1;
+        let witnessUtxo: liquid.TxOutput | null = null;
+        
+        for (let i = 0; i < spendingTx.outs.length; i++) {
+            try {
+                const outputScript = spendingTx.outs[i].script;
+                const outputAddress = liquid.address.fromOutputScript(outputScript, network);
+                if (outputAddress === contractAddress) {
+                    contractOutputIndex = i;
+                    outputValue = Buffer.isBuffer(spendingTx.outs[i].value) 
+                        ? Number(Buffer.from(spendingTx.outs[i].value).reverse().readBigUInt64LE(0))
+                        : Number(spendingTx.outs[i].value);
+                    witnessUtxo = spendingTx.outs[i];
+                    break;
+                }
+            } catch (e) {
+                throw new Error(`Error parsing output script: ${e}`);
+            }
+        }
+        assert(contractOutputIndex !== -1, 'Contract output not found in spending transaction');
+        assert(witnessUtxo != null, 'Witness utxo not found in spending transaction');
+        return {
+            contractOutputIndex,
+            outputValue,
+            witnessUtxo,
+        };
     }
 }

--- a/server-backend/src/SwapOutRunner.ts
+++ b/server-backend/src/SwapOutRunner.ts
@@ -134,10 +134,14 @@ export class SwapOutRunner {
             if (swap.chain === 'LIQUID') {
                 const refundTx = await this.buildLiquidRefundTx(swap);
                 await this.nbxplorer.broadcastTx(refundTx, 'lbtc');
-                await this.lnd.cancelInvoice(swap.preImageHash);
             } else if (swap.chain === 'BITCOIN') {
                 const refundTx = this.buildRefundTx(swap, Transaction.fromBuffer(swap.lockTx), await this.bitcoinService.getMinerFeeRate('low_prio'));
                 await this.nbxplorer.broadcastTx(refundTx);
+            }
+            try {
+                await this.lnd.cancelInvoice(swap.preImageHash);
+            } catch (e) {
+                this.logger.warn(`Error cancelling invoice after expiry (id=${this.swap.id})`, e);
             }
         }
     }

--- a/server-backend/src/SwapOutRunner.ts
+++ b/server-backend/src/SwapOutRunner.ts
@@ -19,7 +19,7 @@ import { clearInterval } from 'node:timers';
 import * as liquid from 'liquidjs-lib';
 import { liquid as liquidNetwork, regtest as liquidRegtest } from 'liquidjs-lib/src/networks.js';
 import { bitcoin } from 'bitcoinjs-lib/src/networks.js';
-import { getLiquidNetwork, LiquidLockPSETBuilder, LiquidRefundPSETBuilder, liquidReverseSwapScript } from './LiquidUtils.js';
+import { getLiquidNetwork, LiquidLockPSETBuilder, LiquidRefundPSETBuilder } from './LiquidUtils.js';
 
 const ECPair = ECPairFactory(ecc);
 
@@ -91,7 +91,7 @@ export class SwapOutRunner {
         } else if (status === 'INVOICE_PAYMENT_INTENT_RECEIVED') {
             if (swap.chain === 'LIQUID') {
                 swap.timeoutBlockHeight = await this.getLiquidCltvExpiry();
-                swap.lockScript = liquidReverseSwapScript(
+                swap.lockScript = reverseSwapScript(
                     swap.preImageHash, 
                     swap.counterpartyPubKey, 
                     ECPair.fromPrivateKey(swap.unlockPrivKey).publicKey, 

--- a/server-backend/src/SwapOutRunner.ts
+++ b/server-backend/src/SwapOutRunner.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { BitcoinConfigurationDetails, BitcoinService } from './BitcoinService.js';
-import { NBXplorerBlockEvent, NBXplorerNewTransactionEvent, NbxplorerService } from './NbxplorerService.js';
+import { NBXplorerLiquidTransactionOutput, NBXplorerBlockEvent, NBXplorerNewTransactionEvent, NbxplorerService } from './NbxplorerService.js';
 import { LndService } from './LndService.js';
 import { SwapOut } from './entities/SwapOut.js';
 import assert from 'node:assert';
@@ -16,6 +16,10 @@ import Decimal from 'decimal.js';
 import moment from 'moment/moment.js';
 import { FourtySwapConfiguration } from './configuration.js';
 import { clearInterval } from 'node:timers';
+import * as liquid from 'liquidjs-lib';
+import { liquid as liquidNetwork, regtest as liquidRegtest } from 'liquidjs-lib/src/networks.js';
+import { bitcoin } from 'bitcoinjs-lib/src/networks.js';
+import { LiquidLockPSETBuilder, LiquidRefundPSETBuilder, liquidReverseSwapScript } from './LiquidUtils.js';
 
 const ECPair = ECPairFactory(ecc);
 
@@ -33,6 +37,7 @@ export class SwapOutRunner {
         private nbxplorer: NbxplorerService,
         private lnd: LndService,
         private swapConfig: FourtySwapConfiguration['swap'],
+        private elementsConfig: FourtySwapConfiguration['elements'],
     ) {
         this.runningPromise = new Promise((resolve) => {
             this.notifyFinished = resolve;
@@ -84,26 +89,59 @@ export class SwapOutRunner {
         if (status === 'CREATED') {
             this.waitForLightningPaymentIntent();
         } else if (status === 'INVOICE_PAYMENT_INTENT_RECEIVED') {
-            swap.timeoutBlockHeight = (await this.getCltvExpiry()) - this.swapConfig.lockBlockDelta.out;
+            if (swap.chain === 'LIQUID') {
+                swap.timeoutBlockHeight = await this.getLiquidCltvExpiry();
+                swap.lockScript = liquidReverseSwapScript(
+                    swap.preImageHash, 
+                    swap.counterpartyPubKey, 
+                    ECPair.fromPrivateKey(swap.unlockPrivKey).publicKey, 
+                    swap.timeoutBlockHeight
+                );
+                const network = this.bitcoinConfig.network === bitcoin ? liquidNetwork : liquidRegtest;
+                const p2wsh = liquid.payments.p2wsh({redeem: { output: swap.lockScript, network }, network});
+                assert(p2wsh.address != null);
+                swap.contractAddress = p2wsh.address;
+                this.swap = await this.repository.save(swap);
+                await this.nbxplorer.trackAddress(p2wsh.address, 'lbtc');
+                const psetBuilder = new LiquidLockPSETBuilder(this.nbxplorer, this.elementsConfig, network);
+                const pset = await psetBuilder.getPset(
+                    swap.outputAmount.mul(1e8).toNumber(), 
+                    p2wsh.address, 
+                    Buffer.alloc(0), // TODO: add a proper blinding key
+                    swap.timeoutBlockHeight
+                );
+                const psetTx = await psetBuilder.getTx(pset);
+                await this.nbxplorer.broadcastTx(psetTx, 'lbtc');
+            } else if (swap.chain === 'BITCOIN') {
+                swap.timeoutBlockHeight = (await this.getCltvExpiry()) - this.swapConfig.lockBlockDelta.out;
+                swap.lockScript = reverseSwapScript(
+                    this.swap.preImageHash,
+                    swap.counterpartyPubKey,
+                    ECPair.fromPrivateKey(swap.unlockPrivKey).publicKey,
+                    swap.timeoutBlockHeight,
+                );
+                const { network } = this.bitcoinConfig;
+                const { address: contractAddress } = payments.p2wsh({network, redeem: { output: swap.lockScript, network }});
+                assert(contractAddress != null);
+                swap.contractAddress = contractAddress;
+                await this.nbxplorer.trackAddress(contractAddress);
+                this.swap = await this.repository.save(swap);
+                await this.lnd.sendCoinsOnChain(contractAddress, swap.outputAmount.mul(1e8).toNumber());
+            }
             this.logger.debug(`Using timeoutBlockHeight=${swap.timeoutBlockHeight} (id=${swap.id})`);
-            swap.lockScript = reverseSwapScript(
-                this.swap.preImageHash,
-                swap.counterpartyPubKey,
-                ECPair.fromPrivateKey(swap.unlockPrivKey).publicKey,
-                swap.timeoutBlockHeight,
-            );
-            const { network } = this.bitcoinConfig;
-            const { address: contractAddress } = payments.p2wsh({network, redeem: { output: swap.lockScript, network }});
-            assert(contractAddress != null);
-            swap.contractAddress = contractAddress;
-            await this.nbxplorer.trackAddress(contractAddress);
-
-            this.swap = await this.repository.save(swap);
-            await this.lnd.sendCoinsOnChain(contractAddress, swap.outputAmount.mul(1e8).toNumber());
         } else if (status === 'CONTRACT_EXPIRED') {
             assert(swap.lockTx != null);
-            const refundTx = this.buildRefundTx(swap, Transaction.fromBuffer(swap.lockTx), await this.bitcoinService.getMinerFeeRate('low_prio'));
-            await this.nbxplorer.broadcastTx(refundTx);
+            if (swap.chain === 'LIQUID') {
+                const network = this.bitcoinConfig.network === bitcoin ? liquidNetwork : liquidRegtest;
+                const psetBuilder = new LiquidRefundPSETBuilder(this.nbxplorer, this.elementsConfig, network);
+                const pset = await psetBuilder.getPset(swap, liquid.Transaction.fromBuffer(swap.lockTx));
+                const psetTx = liquid.Extractor.extract(pset);
+                await this.nbxplorer.broadcastTx(psetTx, 'lbtc');
+                await this.lnd.cancelInvoice(swap.preImageHash);
+            } else if (swap.chain === 'BITCOIN') {
+                const refundTx = this.buildRefundTx(swap, Transaction.fromBuffer(swap.lockTx), await this.bitcoinService.getMinerFeeRate('low_prio'));
+                await this.nbxplorer.broadcastTx(refundTx);
+            }
         }
     }
 
@@ -112,6 +150,15 @@ export class SwapOutRunner {
         assert(invoice.state === 'ACCEPTED');
         assert(invoice.htlcs.length === 1);
         return invoice.htlcs[0].expiryHeight;
+    }
+
+    private async getLiquidCltvExpiry(): Promise<number> {
+        const ratio = 10; // Each bitcoin block is worth 10 liquid blocks (10min - 1min)
+        const currentLiquidHeight = (await this.nbxplorer.getNetworkStatus('lbtc')).chainHeight;
+        const currentBitcoinHeight = (await this.nbxplorer.getNetworkStatus()).chainHeight;
+        const invoiceExpiry = await this.getCltvExpiry();
+        assert(invoiceExpiry > currentBitcoinHeight, `invoiceExpiry=${invoiceExpiry} is not greater than currentBitcoinHeight=${currentBitcoinHeight}`);
+        return currentLiquidHeight + ((invoiceExpiry-currentBitcoinHeight)*ratio);
     }
 
     private async waitForLightningPaymentIntent(): Promise<void> {
@@ -155,7 +202,9 @@ export class SwapOutRunner {
         const { swap } = this;
         const output = event.data.outputs.find(o => o.address === swap.contractAddress);
         assert(output != null);
-        const expectedAmount = new Decimal(output.value).div(1e8);
+        const expectedAmount = swap.chain === 'LIQUID' ? 
+            new Decimal((output as unknown as NBXplorerLiquidTransactionOutput).value.value).div(1e8) : 
+            new Decimal(output.value).div(1e8);
         if (!expectedAmount.equals(swap.outputAmount)) {
             // eslint-disable-next-line max-len
             this.logger.error(`Amount mismatch. Failed swap. Incoming ${expectedAmount.toNumber()}, expected ${swap.outputAmount.toNumber()} (id=${this.swap.id})`);
@@ -180,8 +229,12 @@ export class SwapOutRunner {
     private async processContractSpendingTx(event: NBXplorerNewTransactionEvent): Promise<void> {
         const { swap } = this;
         assert(swap.lockTx != null);
-        const lockTx = Transaction.fromBuffer(swap.lockTx);
-        const unlockTx = Transaction.fromHex(event.data.transactionData.transaction);
+        const lockTx = swap.chain === 'LIQUID' ? 
+            liquid.Transaction.fromBuffer(swap.lockTx) : 
+            Transaction.fromBuffer(swap.lockTx);
+        const unlockTx = swap.chain === 'LIQUID' ? 
+            liquid.Transaction.fromHex(event.data.transactionData.transaction) : 
+            Transaction.fromHex(event.data.transactionData.transaction);
 
         swap.unlockTx = Buffer.from(event.data.transactionData.transaction, 'hex');
         if (event.data.transactionData.height != null) {
@@ -191,7 +244,10 @@ export class SwapOutRunner {
 
         const isSendingToRefundAddress = unlockTx.outs.find(o => {
             try {
-                return address.fromOutputScript(o.script, this.bitcoinConfig.network) === swap.sweepAddress;
+                const sweepAddress = swap.chain === 'LIQUID' ? 
+                    liquid.address.fromOutputScript(o.script, this.bitcoinConfig.network === bitcoin ? liquidNetwork : liquidRegtest) : 
+                    address.fromOutputScript(o.script, this.bitcoinConfig.network);
+                return sweepAddress === swap.sweepAddress;
             } catch (e) {
                 return false;
             }

--- a/server-backend/src/SwapService.ts
+++ b/server-backend/src/SwapService.ts
@@ -176,6 +176,7 @@ export class SwapService implements OnApplicationBootstrap, OnApplicationShutdow
             this.nbxplorer,
             this.lnd,
             this.swapConfig,
+            this.elementsConfig,
         );
         this.runAndMonitor(swap, runner);
         return swap;
@@ -228,6 +229,7 @@ export class SwapService implements OnApplicationBootstrap, OnApplicationShutdow
                 this.nbxplorer,
                 this.lnd,
                 this.swapConfig,
+                this.elementsConfig,
             );
             this.logger.log(`Resuming swap (id=${swap.id})`);
             this.runAndMonitor(swap, runner);


### PR DESCRIPTION
Added Liquid Network support to the 40Swap platform. Key changes include:

- Added LiquidService.ts and LiquidUtils.ts to handle Liquid blockchain interactions
- Modified SwapOutRunner.ts to support both Bitcoin and Liquid chains
- Implemented PSET (Partially Signed Elements Transaction) builders for Liquid transactions
- Created Liquid-specific scripts and timeout calculations
