### PR TITLE
Allow customizable max iterations and delay in waitFor function

### DIFF
--- a/server-backend/test/utils.ts
+++ b/server-backend/test/utils.ts
@@ -14,8 +14,8 @@ export function sleep(ms = 1000): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export async function waitFor(fn: () => Promise<boolean>): Promise<void> {
-    for (let i = 0; i < 5; i++) {
+export async function waitFor(fn: () => Promise<boolean>, maxIterations = 6, delay = 10000): Promise<void> {
+    for (let i = 0; i < maxIterations; i++) {
         try {
             const res = await fn();
             if (res) {
@@ -24,7 +24,7 @@ export async function waitFor(fn: () => Promise<boolean>): Promise<void> {
         } catch (e) {
             console.error(e);
         }
-        await sleep(1000);
+        await sleep(delay);
     }
     throw new Error('timeout');
 }

--- a/server-backend/test/utils.ts
+++ b/server-backend/test/utils.ts
@@ -15,7 +15,7 @@ export function sleep(ms = 1000): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export async function waitFor(fn: () => Promise<boolean>, maxIterations = 6, delay = 10000): Promise<void> {
+export async function waitFor(fn: () => Promise<boolean>, maxIterations = 6, delay = 5000): Promise<void> {
     for (let i = 0; i < maxIterations; i++) {
         try {
             const res = await fn();


### PR DESCRIPTION
Enhance the `waitFor` function in integration tests to accept customizable maximum iterations and delay parameters, improving flexibility in test execution.

On GH the tests are timing out as it is too strict right now.