### PR TITLE
fix integration tests

### DIFF
--- a/server-backend/src/utils.ts
+++ b/server-backend/src/utils.ts
@@ -1,6 +1,6 @@
 export function sleep(millis: number, abortSignal?: AbortSignal): Promise<void> {
     const safeTestingTime = Math.min(1000, millis); // This allow us to correctly execute integration tests
-    // We need to make sure that the timeout is at least 1 second, otherwise the test will fail
+    // We need to make sure that the timeout is at most 1 second, otherwise the integration tests will fail.
     // This is because integration tests runs an image of the server so we cant control time neither mock it
     // More info here: https://github.com/40acres/40swap/pull/96
     const timeoutPromise = new Promise<void>(r => setTimeout(r, process.env.IS_TESTING ? safeTestingTime : millis));

--- a/server-backend/src/utils.ts
+++ b/server-backend/src/utils.ts
@@ -1,5 +1,5 @@
 export function sleep(millis: number, abortSignal?: AbortSignal): Promise<void> {
-    const timeoutPromise = new Promise<void>(r => setTimeout(r, millis));
+    const timeoutPromise = new Promise<void>(r => setTimeout(r, process.env.TEST_MODE ? 1000 : millis));
     if (abortSignal != null) {
         return Promise.any([
             timeoutPromise,

--- a/server-backend/src/utils.ts
+++ b/server-backend/src/utils.ts
@@ -1,5 +1,9 @@
 export function sleep(millis: number, abortSignal?: AbortSignal): Promise<void> {
-    const timeoutPromise = new Promise<void>(r => setTimeout(r, process.env.TEST_MODE ? 1000 : millis));
+    const safeTestingTime = Math.min(1000, millis); // This allow us to correctly execute integration tests
+    // We need to make sure that the timeout is at least 1 second, otherwise the test will fail
+    // This is because integration tests runs an image of the server so we cant control time neither mock it
+    // More info here: https://github.com/40acres/40swap/pull/96
+    const timeoutPromise = new Promise<void>(r => setTimeout(r, process.env.IS_TESTING ? safeTestingTime : millis));
     if (abortSignal != null) {
         return Promise.any([
             timeoutPromise,

--- a/server-backend/test/integration.test.ts
+++ b/server-backend/test/integration.test.ts
@@ -7,7 +7,7 @@ import { Lnd } from './Lnd';
 import { Bitcoind } from './Bitcoind';
 import { BackendRestClient } from './BackendRestClient';
 import { ECPair, waitFor, waitForChainSync } from './utils';
-import { networks, payments } from 'bitcoinjs-lib';
+import { networks } from 'bitcoinjs-lib';
 import { jest } from '@jest/globals';
 
 jest.setTimeout(2 * 60 * 1000);
@@ -115,7 +115,7 @@ describe('40Swap backend', () => {
         });
 
         // Now request a refund
-        const refundPSBT = await backend.getRefundPsbt(swap.swapId, "bcrt1qls85t60c5ggt3wwh7d5jfafajnxlhyelcsm3sf");
+        const refundPSBT = await backend.getRefundPsbt(swap.swapId, 'bcrt1qls85t60c5ggt3wwh7d5jfafajnxlhyelcsm3sf');
 
         // Sign the refund transaction
         signContractSpend({
@@ -140,7 +140,7 @@ describe('40Swap backend', () => {
         const configFilePath = `${os.tmpdir()}/40swap-test-${crypto.randomBytes(4).readUInt32LE(0)}.yml`;
         const composeDef = new DockerComposeEnvironment('test/resources', 'docker-compose.yml')
             .withBuild()
-            .withWaitStrategy('40swap-backend-1', Wait.forHealthCheck())
+            .withWaitStrategy('40swap_backend', Wait.forHealthCheck())
             .withWaitStrategy('40swap_lnd_lsp', Wait.forLogMessage(/.*Waiting for chain backend to finish sync.*/))
             .withWaitStrategy('40swap_lnd_alice', Wait.forLogMessage(/.*Waiting for chain backend to finish sync.*/))
             .withWaitStrategy('40swap_lnd_user', Wait.forLogMessage(/.*Waiting for chain backend to finish sync.*/))
@@ -176,6 +176,7 @@ describe('40Swap backend', () => {
                 maximumAmount: 0.01300000,
                 expiryDuration: 'PT30M',
                 lockBlockDelta: {
+                    minIn: 144,
                     in: 432,
                     out: 20,
                 },
@@ -199,7 +200,7 @@ describe('40Swap backend', () => {
         lndUser = await Lnd.fromContainer(compose.getContainer('40swap_lnd_user'));
         lndAlice = await Lnd.fromContainer(compose.getContainer('40swap_lnd_alice'));
         bitcoind = new Bitcoind(compose.getContainer('40swap_bitcoind'));
-        backend = new BackendRestClient(compose.getContainer('40swap-backend-1'));
+        backend = new BackendRestClient(compose.getContainer('40swap_backend'));
     }
 
     async function setUpBlockchains(): Promise<void> {

--- a/server-backend/test/resources/docker-compose.yml
+++ b/server-backend/test/resources/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       nbxplorer:
         condition: service_started
     environment:
-      - TEST_MODE=true
+      - IS_TESTING=true
     healthcheck:
       test: curl --fail http://localhost:8081/api/health || exit 1
       interval: 3s

--- a/server-backend/test/resources/docker-compose.yml
+++ b/server-backend/test/resources/docker-compose.yml
@@ -1,7 +1,8 @@
 include:
   - "../../../docker/docker-compose.yml"
 services:
-  40swap-backend:
+  backend:
+    container_name: 40swap_backend
     image: 40swap-server-backend
     build:
       context: ../../..
@@ -15,6 +16,8 @@ services:
         condition: service_started
       nbxplorer:
         condition: service_started
+    environment:
+      - TEST_MODE=true
     healthcheck:
       test: curl --fail http://localhost:8081/api/health || exit 1
       interval: 3s

--- a/server-backend/test/utils.ts
+++ b/server-backend/test/utils.ts
@@ -26,5 +26,5 @@ export async function waitFor(fn: () => Promise<boolean>): Promise<void> {
         }
         await sleep(1000);
     }
-    throw new Error('timeout');
+    throw new Error(`timeout while waiting for condition: ${fn.toString()}`);
 }


### PR DESCRIPTION
We were facing an issue with the `sleep` function during the tests. We were using 300000 milliseconds, which  made the test fail because of "inaction" since the code was waiting for so long. 

Since these are integration tests (this implies that we don't test the code itself, we build it and interact with it through the api in a docker container), we could not use mocks, patchers or make use of the jest timing functions.

The solution is to introduce an env variable to the backend and if is in test mode, force the `sleep` function to always sleep for 1 second.