### PR TITLE
Remove awaiting on status changes to prevent swaps being not processed

### DIFF
--- a/server-backend/src/SwapInRunner.ts
+++ b/server-backend/src/SwapInRunner.ts
@@ -151,7 +151,7 @@ export class SwapInRunner {
             if (this.swap.status === 'CREATED') {
                 swap.status = 'CONTRACT_FUNDED_UNCONFIRMED';
                 this.swap = await this.repository.save(swap);
-                await this.onStatusChange('CONTRACT_FUNDED_UNCONFIRMED');
+                void this.onStatusChange('CONTRACT_FUNDED_UNCONFIRMED');
             } else {
                 this.swap = await this.repository.save(swap);
             }
@@ -183,13 +183,13 @@ export class SwapInRunner {
                 if (this.swap.status === 'INVOICE_PAID') {
                     swap.status = 'CONTRACT_CLAIMED_UNCONFIRMED';
                     this.swap = await this.repository.save(swap);
-                    await this.onStatusChange('CONTRACT_CLAIMED_UNCONFIRMED');
+                    void this.onStatusChange('CONTRACT_CLAIMED_UNCONFIRMED');
                 }
             } else {
                 if (this.swap.status === 'CONTRACT_EXPIRED') {
                     swap.status = 'CONTRACT_REFUNDED_UNCONFIRMED';
                     this.swap = await this.repository.save(swap);
-                    await this.onStatusChange('CONTRACT_REFUNDED_UNCONFIRMED');
+                    void this.onStatusChange('CONTRACT_REFUNDED_UNCONFIRMED');
                 }
             }
         }
@@ -200,21 +200,21 @@ export class SwapInRunner {
         if ((swap.status === 'CONTRACT_FUNDED' || swap.status === 'CONTRACT_FUNDED_UNCONFIRMED') && swap.timeoutBlockHeight <= event.data.height) {
             swap.status = 'CONTRACT_EXPIRED';
             this.swap = await this.repository.save(swap);
-            await this.onStatusChange('CONTRACT_EXPIRED');
+            void this.onStatusChange('CONTRACT_EXPIRED');
         } else if (swap.status === 'CONTRACT_FUNDED_UNCONFIRMED' && this.bitcoinService.hasEnoughConfirmations(swap.lockTxHeight, event.data.height)) {
             swap.status = 'CONTRACT_FUNDED';
             this.swap = await this.repository.save(swap);
-            await this.onStatusChange('CONTRACT_FUNDED');
+            void this.onStatusChange('CONTRACT_FUNDED');
         } else if (swap.status === 'CONTRACT_REFUNDED_UNCONFIRMED' && this.bitcoinService.hasEnoughConfirmations(swap.unlockTxHeight, event.data.height)) {
             swap.status = 'DONE';
             swap.outcome = 'REFUNDED';
             this.swap = await this.repository.save(swap);
-            await this.onStatusChange('DONE');
+            void this.onStatusChange('DONE');
         } else if (swap.status === 'CONTRACT_CLAIMED_UNCONFIRMED' && this.bitcoinService.hasEnoughConfirmations(swap.unlockTxHeight, event.data.height)) {
             swap.status = 'DONE';
             swap.outcome = 'SUCCESS';
             this.swap = await this.repository.save(swap);
-            await this.onStatusChange('DONE');
+            void this.onStatusChange('DONE');
         }
     }
 

--- a/server-backend/src/SwapOutRunner.ts
+++ b/server-backend/src/SwapOutRunner.ts
@@ -220,7 +220,7 @@ export class SwapOutRunner {
             if (this.swap.status === 'INVOICE_PAYMENT_INTENT_RECEIVED') {
                 swap.status = 'CONTRACT_FUNDED_UNCONFIRMED';
                 this.swap = await this.repository.save(swap);
-                await this.onStatusChange('CONTRACT_FUNDED_UNCONFIRMED');
+                void this.onStatusChange('CONTRACT_FUNDED_UNCONFIRMED');
             } else {
                 this.swap = await this.repository.save(swap);
             }
@@ -258,7 +258,7 @@ export class SwapOutRunner {
             if (this.swap.status === 'CONTRACT_EXPIRED') {
                 swap.status = 'CONTRACT_REFUNDED_UNCONFIRMED';
                 this.swap = await this.repository.save(swap);
-                await this.onStatusChange('CONTRACT_REFUNDED_UNCONFIRMED');
+                void this.onStatusChange('CONTRACT_REFUNDED_UNCONFIRMED');
             }
         } else {
             const input = unlockTx.ins.find(i => Buffer.from(i.hash).equals(lockTx.getHash()));
@@ -285,16 +285,16 @@ export class SwapOutRunner {
         if (swap.status === 'CONTRACT_FUNDED'  && swap.timeoutBlockHeight <= event.data.height) {
             swap.status = 'CONTRACT_EXPIRED';
             this.swap = await this.repository.save(swap);
-            await this.onStatusChange('CONTRACT_EXPIRED');
+            void this.onStatusChange('CONTRACT_EXPIRED');
         } else if (swap.status === 'CONTRACT_FUNDED_UNCONFIRMED' && this.bitcoinService.hasEnoughConfirmations(swap.lockTxHeight, event.data.height)) {
             swap.status = 'CONTRACT_FUNDED';
             this.swap = await this.repository.save(swap);
-            await this.onStatusChange('CONTRACT_FUNDED');
+            void this.onStatusChange('CONTRACT_FUNDED');
         } else if (swap.status === 'CONTRACT_REFUNDED_UNCONFIRMED' && this.bitcoinService.hasEnoughConfirmations(swap.unlockTxHeight, event.data.height)) {
             swap.status = 'DONE';
             swap.outcome = 'REFUNDED';
             this.swap = await this.repository.save(swap);
-            await this.onStatusChange('DONE');
+            void this.onStatusChange('DONE');
         } else if (swap.status === 'CONTRACT_CLAIMED_UNCONFIRMED' && this.bitcoinService.hasEnoughConfirmations(swap.unlockTxHeight, event.data.height)) {
             assert(swap.preImage != null);
             this.logger.log(`Settling invoice (id=${this.swap.id})`);
@@ -302,7 +302,7 @@ export class SwapOutRunner {
             swap.status = 'DONE';
             swap.outcome = 'SUCCESS';
             this.swap = await this.repository.save(swap);
-            await this.onStatusChange('DONE');
+            void this.onStatusChange('DONE');
         }
     }
 


### PR DESCRIPTION
 onStatusChange calls are not awaited anymore avoiding potential blocking on swaps processing when status changes are long-lived such  a retry on a LND payment