### PR TITLE
Add force parameter to closeChannel method on integration tests bootstrap

### DIFF
--- a/server-backend/test/Lnd.ts
+++ b/server-backend/test/Lnd.ts
@@ -124,10 +124,11 @@ export class Lnd {
         });
     }
 
-    async closeChannel(channelPoint: ChannelPoint): Promise<void> {
+    async closeChannel(channelPoint: ChannelPoint, force: boolean = false): Promise<void> {
         return new Promise((resolve, reject) => {
             const call = this.client.closeChannel({
-                channelPoint,
+                channelPoint: channelPoint,
+                force: force,
             });
             call.on('data', async (update: CloseStatusUpdate) => {
                 if (update.closePending != null) {

--- a/server-backend/test/integration.test.ts
+++ b/server-backend/test/integration.test.ts
@@ -292,18 +292,19 @@ describe('40Swap backend', () => {
         await lndLsp.connect(lndUser.uri);
         await lndAlice.connect(lndUser.uri);
         await waitForChainSync(allLnds);
-        await lndLsp.openChannel(lndAlice.pubkey, 0.05);
-        await lndAlice.openChannel(lndUser.pubkey, 0.05);
-        await lndUser.openChannel(lndAlice.pubkey, 0.05);
-        await lndAlice.openChannel(lndLsp.pubkey, 0.05);
+        await lndLsp.openChannel(lndAlice.pubkey, 0.16);
+        await lndAlice.openChannel(lndUser.pubkey, 0.16);
+        await lndUser.openChannel(lndAlice.pubkey, 0.16);
+        await lndAlice.openChannel(lndLsp.pubkey, 0.16);
         await bitcoind.mine();
         await waitForChainSync(allLnds);
 
         // just to bootstrap the graph
-        const ch = await lndLsp.openChannel(lndUser.pubkey, 0.05);
+        const ch = await lndLsp.openChannel(lndUser.pubkey, 0.16);
         await bitcoind.mine();
         await waitForChainSync(allLnds);
-        await lndLsp.closeChannel(ch);
+        // Force close the channel to avoid flaky issue 'unable to gracefully close  channel while peer is offline (try force closing it instead):  channel link not found'
+        await lndLsp.closeChannel(ch, true);
         await bitcoind.mine();
         await waitForChainSync(allLnds);
         await waitFor(async () => (await lndLsp.describeGraph()).nodes?.length === 3);


### PR DESCRIPTION
Introduce a force parameter to the closeChannel method to address issues with LND connections. 

For some reason, when closing the channel on the igtest bootstrap fail with:

`unable to gracefully close  channel while peer is offline (try force closing it instead):  channel link not found`
LLabs also has this issue on their end and they fix it by reconnecting the peer, I tried it without success so this workaround works.

Bonus: increase channel capacities to have more bandwith for incoming tests
