### PR TITLE
Handle RPC Wallet

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -63,17 +63,17 @@ sendtoaddress address amount:
 
 # Send to address with fee rate and generate blocks for Liquid
 elements-sendtoaddress address amount:
-    just elements-cli -named sendtoaddress address={{address}} amount={{amount}} fee_rate=25
+    just elements-cli -rpcwallet=main -named sendtoaddress address={{address}} amount={{amount}} fee_rate=25
     just generate 6
 
 # Generate blocks for both bitcoin and liquid
 generate blocks:
     docker exec --user bitcoin 40swap_bitcoind bitcoin-cli -regtest -generate {{blocks}}
-    docker exec -it 40swap_elements elements-cli -chain=liquidregtest -generate {{blocks}}
+    docker exec -it 40swap_elements elements-cli -chain=liquidregtest -rpcwallet=main -generate {{blocks}}
 
 # Generate blocks(mining) for Liquid
 generate-liquid blocks='1':
-    docker exec -it 40swap_elements elements-cli -chain=liquidregtest -generate {{blocks}}
+    docker exec -it 40swap_elements elements-cli -chain=liquidregtest -rpcwallet=main -generate {{blocks}}
 
 # Generate blocks(mining) for Bitcoin
 generate-bitcoin blocks='6':
@@ -93,7 +93,8 @@ alice-lncli *cmd:
 
 # Run command within elements container
 elements-cli *cmd:
-    docker exec -it 40swap_elements elements-cli -chain=liquidregtest  {{cmd}}
+    docker exec -it 40swap_elements elements-cli -chain=liquidregtest -rpcwallet=main {{cmd}}
+
 # Run backend IgTests
 [working-directory: 'server-backend']
 test-igtest-backend: build-shared 

--- a/docker/nodes-setup.sh
+++ b/docker/nodes-setup.sh
@@ -89,12 +89,10 @@ EOM
 echo "$dev_config" > ../server-backend/dev/40swap.lightning.yml
 
 # Liquid setup:
-docker exec -it 40swap_elements elements-cli -chain=liquidregtest unloadwallet ""
-docker exec -it 40swap_elements rm -r -f '/home/elements/.elements/liquidregtest/wallets/database' '/home/elements/.elements/liquidregtest/wallets/db.log' '/home/elements/.elements/liquidregtest/wallets/wallet.dat'
-docker exec -it 40swap_elements elements-cli -chain=liquidregtest createwallet "" false false "" false true true false
-address=$(docker exec -i 40swap_elements elements-cli -chain=liquidregtest getnewaddress | tr -d '\r\n' | xargs)
-docker exec -it 40swap_elements elements-cli -chain=liquidregtest generatetoaddress 101 $address
-xpub=$(docker exec -it 40swap_elements elements-cli -chain=liquidregtest listdescriptors | jq -r '.descriptors[] | select(.desc | startswith("wpkh(")) | select(.internal==false) | .desc' | sed -E 's/.*\]([^\/]+)\/.*/\1/')
+docker exec -it 40swap_elements elements-cli -chain=liquidregtest createwallet "main" false false "" false true true false
+address=$(docker exec -i 40swap_elements elements-cli -chain=liquidregtest -rpcwallet=main getnewaddress | tr -d '\r\n' | xargs)
+docker exec -it 40swap_elements elements-cli -chain=liquidregtest -rpcwallet=main generatetoaddress 101 $address
+xpub=$(docker exec -it 40swap_elements elements-cli -chain=liquidregtest -rpcwallet=main listdescriptors | jq -r '.descriptors[] | select(.desc | startswith("wpkh(")) | select(.internal==false) | .desc' | sed -E 's/.*\]([^\/]+)\/.*/\1/')
 
 set the xpub of the liquid wallet
 read -r -d '' xpub_config << EOM
@@ -104,6 +102,7 @@ elements:
   rpcUrl: http://localhost:18884
   rpcUsername: 40swap
   rpcPassword: pass
+  rpcWallet: main
   xpub: $xpub
   esploraUrl: http://localhost:35000
 EOM

--- a/server-backend/src/LiquidService.ts
+++ b/server-backend/src/LiquidService.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 const LiquidConfigurationDetailsSchema = z.object({
     rpcUrl: z.string(),
     rpcAuth: z.object({
+        wallet: z.string(),
         username: z.string(),
         password: z.string(),
     }),
@@ -71,7 +72,7 @@ export class LiquidService implements OnApplicationBootstrap  {
     public readonly xpub: string;
     private readonly logger = new Logger(LiquidService.name);
     private readonly rpcUrl: string;
-    private readonly rpcAuth: {username: string, password: string};
+    private readonly rpcAuth: {username: string, password: string, wallet: string};
 
     constructor(
         private nbxplorer: NbxplorerService,
@@ -82,8 +83,10 @@ export class LiquidService implements OnApplicationBootstrap  {
         this.rpcAuth = {
             username: this.elementsConfig.rpcUsername,
             password: this.elementsConfig.rpcPassword,
+            wallet: this.elementsConfig.rpcWallet,
         };
         this.configurationDetails = LiquidConfigurationDetailsSchema.parse({
+            wallet: this.elementsConfig.rpcWallet,
             rpcUrl: this.rpcUrl,
             rpcAuth: this.rpcAuth,
             xpub: this.xpub,
@@ -102,10 +105,10 @@ export class LiquidService implements OnApplicationBootstrap  {
         }
     }
 
-    async callRPC(method: string, params: unknown[] = []): Promise<unknown> {
+    async callRPC(method: string, params: unknown[] = [], wallet: string = this.rpcAuth.wallet): Promise<unknown> {
         try {
             const authString = Buffer.from(`${this.rpcAuth.username}:${this.rpcAuth.password}`).toString('base64');
-            const response = await fetch(this.rpcUrl, {
+            const response = await fetch(`${this.rpcUrl}/wallet/${wallet}`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/server-backend/src/SwapInController.ts
+++ b/server-backend/src/SwapInController.ts
@@ -169,6 +169,7 @@ export class SwapInController {
             rpcUrl: this.liquidService.configurationDetails.rpcUrl,
             rpcUsername: this.liquidService.configurationDetails.rpcAuth.username,
             rpcPassword: this.liquidService.configurationDetails.rpcAuth.password,
+            rpcWallet: this.liquidService.configurationDetails.rpcAuth.wallet,
             esploraUrl: this.liquidService.configurationDetails.esploraUrl,
         }, network);
         const pset = await psetBuilder.getPset(swap, liquid.Transaction.fromBuffer(swap.lockTx!), outputAddress);

--- a/server-backend/src/SwapOutController.ts
+++ b/server-backend/src/SwapOutController.ts
@@ -165,6 +165,7 @@ export class SwapOutController {
             rpcUrl: this.liquidService.configurationDetails.rpcUrl,
             rpcUsername: this.liquidService.configurationDetails.rpcAuth.username,
             rpcPassword: this.liquidService.configurationDetails.rpcAuth.password,
+            rpcWallet: this.liquidService.configurationDetails.rpcAuth.wallet,
             esploraUrl: this.liquidService.configurationDetails.esploraUrl,
         }, liquidNetwork);
         const lockTx = liquid.Transaction.fromBuffer(swap.lockTx!);

--- a/server-backend/src/configuration.ts
+++ b/server-backend/src/configuration.ts
@@ -64,6 +64,7 @@ export const configSchema = z.object({
         rpcUrl: z.string().url(),
         rpcUsername: z.string(),
         rpcPassword: z.string(),
+        rpcWallet: z.string(),
         esploraUrl: z.string().url(),
     }),
 });

--- a/server-backend/test/Elements.ts
+++ b/server-backend/test/Elements.ts
@@ -3,10 +3,11 @@ import { StartedGenericContainer } from 'testcontainers/build/generic-container/
 export class Elements {
     constructor(
         private container: StartedGenericContainer,
+        private walletName: string = 'main',
     ) {}
 
     async mine(blocks = 3): Promise<void> {
-        const res = await this.container.exec(`elements-cli -chain=liquidregtest -generate ${blocks}`);
+        const res = await this.container.exec(`elements-cli -chain=liquidregtest -rpcwallet=${this.walletName} -generate ${blocks}`);
         if (res.exitCode !== 0) {
             throw new Error(`command failed: ${res.stdout} ${res.stderr}`);
         }
@@ -14,7 +15,7 @@ export class Elements {
     }
 
     async sendToAddress(address: string, amount: number): Promise<void> {
-        const res = await this.container.exec(`elements-cli -chain=liquidregtest -named sendtoaddress address=${address} amount=${amount} fee_rate=25`);
+        const res = await this.container.exec(`elements-cli -chain=liquidregtest -rpcwallet=${this.walletName} -named sendtoaddress address=${address} amount=${amount} fee_rate=25`);
         if (res.exitCode !== 0) {
             throw new Error(`command failed: ${res.stdout} ${res.stderr}`);
         }
@@ -22,7 +23,7 @@ export class Elements {
     }
 
     async getNewAddress(): Promise<string> {
-        const res = await this.container.exec('elements-cli -chain=liquidregtest getnewaddress');
+        const res = await this.container.exec(`elements-cli -chain=liquidregtest -rpcwallet=${this.walletName} getnewaddress`);
         if (res.exitCode !== 0) {
             throw new Error(`command failed: ${res.stdout} ${res.stderr}`);
         }
@@ -30,7 +31,7 @@ export class Elements {
     }
 
     async getXpub(): Promise<string> {
-        const res = await this.container.exec('elements-cli -chain=liquidregtest listdescriptors');
+        const res = await this.container.exec(`elements-cli -chain=liquidregtest -rpcwallet=${this.walletName} listdescriptors`);
         if (res.exitCode !== 0) {
             throw new Error(`command failed: ${res.stdout} ${res.stderr}`);
         }
@@ -47,22 +48,16 @@ export class Elements {
     }
 
     async startDescriptorWallet(): Promise<void> {
-        // First unload the wallet
-        await this.container.exec('elements-cli -chain=liquidregtest unloadwallet ""');
-        
-        // Remove original wallet files
-        await this.container.exec('rm -r -f /home/elements/.elements/liquidregtest/wallets/*');
-        
         // Create a new wallet
         // eslint-disable-next-line quotes
-        const res = await this.container.exec(`elements-cli -chain=liquidregtest createwallet  false false  false true true false`);
+        const res = await this.container.exec(`elements-cli -chain=liquidregtest createwallet ${this.walletName} false false  false true true false`);
         if (res.exitCode !== 0) {
             throw new Error(`command failed: ${res.stdout} ${res.stderr}`);
         }
     }
 
     async getBlockHeight(): Promise<number> {
-        const res = await this.container.exec('elements-cli -chain=liquidregtest getblockcount');
+        const res = await this.container.exec(`elements-cli -chain=liquidregtest -rpcwallet=${this.walletName} getblockcount`);
         if (res.exitCode !== 0) {
             throw new Error(`command failed: ${res.stdout} ${res.stderr}`);
         }

--- a/server-backend/test/integration.test.ts
+++ b/server-backend/test/integration.test.ts
@@ -342,6 +342,7 @@ describe('40Swap backend', () => {
                 rpcUrl: 'http://elements:18884',
                 rpcUsername: '40swap',
                 rpcPassword: 'pass',
+                rpcWallet: 'main',
                 esploraUrl: 'http://localhost:3000',
                 xpub,
             },

--- a/server-backend/test/integration.test.ts
+++ b/server-backend/test/integration.test.ts
@@ -293,7 +293,8 @@ describe('40Swap backend', () => {
         compose = await composeDef.up(['lnd-lsp', 'elements']);
 
         lndLsp = await Lnd.fromContainer(compose.getContainer('40swap_lnd_lsp'));
-        elements = new Elements(compose.getContainer('40swap_elements'));
+        const elementsWalletName = 'main';
+        elements = new Elements(compose.getContainer('40swap_elements'), elementsWalletName);
         // Initialize Elements wallet and get xpub
         await elements.startDescriptorWallet();
         await elements.mine(101);
@@ -342,7 +343,7 @@ describe('40Swap backend', () => {
                 rpcUrl: 'http://elements:18884',
                 rpcUsername: '40swap',
                 rpcPassword: 'pass',
-                rpcWallet: 'main',
+                rpcWallet: elementsWalletName,
                 esploraUrl: 'http://localhost:3000',
                 xpub,
             },


### PR DESCRIPTION
## 📄 Description
This PR introduces a way to handle which wallet we interact with through RPC on the Elements service. This is needed in order to be able to work with more than 2 wallets.