### PR TITLE
Improve formatter

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,4 +5,7 @@ coverage
 .vscode
 .github
 docker
-*.d.ts 
+package-lock.json
+*.d.ts
+server-backend/lnd/**/*
+server-backend/migrations/**/*

--- a/.eslintignore
+++ b/.eslintignore
@@ -7,5 +7,5 @@ coverage
 docker
 package-lock.json
 *.d.ts
-server-backend/lnd/**/*
-server-backend/migrations/**/*
+server-backend/src/lnd/**/*
+server-backend/src/migrations/**/*

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,6 @@
         "eslint-config-prettier"
     ],
     "root": true,
-    "ignorePatterns": [".eslintrc.json"],
     "rules": {
         "prettier/prettier": "error",
         "@typescript-eslint/interface-name-prefix": "off",

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,4 +6,6 @@ coverage
 .github
 docker
 package-lock.json
-*.d.ts 
+*.d.ts
+server-backend/lnd/**/*
+server-backend/migrations/**/*

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,5 +7,5 @@ coverage
 docker
 package-lock.json
 *.d.ts
-server-backend/lnd/**/*
-server-backend/migrations/**/*
+server-backend/src/lnd/**/*
+server-backend/src/migrations/**/*

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
         "lint": "eslint \"**/*.{js,jsx,ts,tsx}\"",
         "lint:fix": "eslint \"**/*.{js,jsx,ts,tsx}\" --fix",
         "lint:check": "eslint \"**/*.{js,jsx,ts,tsx}\"",
-        "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
-        "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,md}\""
+        "format": "prettier --write \"**/*.{js,jsx,ts,tsx}\"",
+        "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx}\""
     },
     "workspaces": [
         "server-backend",


### PR DESCRIPTION
## 📄 Description
Now we apply the formatter only for `ts,tsx,js,jsx` files and some autogenerated foldes like `src/migrations/**` or `src/lnd/**`. 

The result of applying the formatter with these changes results in the following files changed:

![CleanShot 2025-06-11 at 13 34 49](https://github.com/user-attachments/assets/7e8b1856-f22d-48c8-a211-991bc33e87ca)
