### PR TITLE
Release CI to support 40swapd versioning

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -104,14 +104,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Log into the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta-fe
-        uses: docker/metadata-action@v5.0.0
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_FRONTEND }}
           tags: |

--- a/.github/workflows/daemon.yaml
+++ b/.github/workflows/daemon.yaml
@@ -9,7 +9,7 @@ on:
       - "daemon/**"
       - ".github/workflows/daemon.yaml"
     tags:
-      - "*"
+      - "40swapd/*"
 
   pull_request:
     branches:
@@ -74,6 +74,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Subtract '40swapd/' from tag name
+        id: clean_tag_name
+        run: |
+          echo "tag_name=${GITHUB_REF##refs/tags/}" >> $GITHUB_ENV
+          echo "clean_tag_name=${tag_name##40swapd\/}" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Log into the Container registry
@@ -84,7 +89,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}/40swapd
           labels: |
@@ -94,8 +99,13 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}},event=tag,value=${{ steps.clean_tag_name.outputs.clean_tag_name }}
       - name: Build and push the Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: daemon
           file: daemon/docker/Dockerfile


### PR DESCRIPTION
@Jossec101 I think this change may do the trick to support what you are planning to use as release format here.

- For 40swap, the backend and frontend, just normal releases using whatever as tag, preferably a semver (I can use this PR to force this tag to be semver compatible at 40swap too).

- For 40swapd it does expect a tag named `40swapd/<semver compatible string>` it will subtract this `40swapd/` and tag the resulting image as just `<semver compatible string>` removing `v` prefix if given.


I would need to test this in a live scenario but I am pretty sure it gonna work.