### PR TITLE
Fix network missmatch

### DIFF
--- a/daemon/swaps/40swap_test.go
+++ b/daemon/swaps/40swap_test.go
@@ -1,0 +1,69 @@
+package swaps
+
+import (
+	"testing"
+
+	"github.com/40acres/40swap/daemon/lightning"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_mapServerNetworkToDaemonNetwork(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverNetwork  string
+		expectedResult lightning.Network
+		expectError    bool
+	}{
+		{
+			name:           "bitcoin maps to mainnet",
+			serverNetwork:  "bitcoin",
+			expectedResult: lightning.Mainnet,
+			expectError:    false,
+		},
+		{
+			name:           "mainnet maps to mainnet (backward compatibility)",
+			serverNetwork:  "mainnet",
+			expectedResult: lightning.Mainnet,
+			expectError:    false,
+		},
+		{
+			name:           "regtest maps to regtest",
+			serverNetwork:  "regtest",
+			expectedResult: lightning.Regtest,
+			expectError:    false,
+		},
+		{
+			name:           "testnet maps to testnet",
+			serverNetwork:  "testnet",
+			expectedResult: lightning.Testnet,
+			expectError:    false,
+		},
+		{
+			name:           "unsupported network returns error",
+			serverNetwork:  "liquidv1",
+			expectedResult: "",
+			expectError:    true,
+		},
+		{
+			name:           "empty string returns error",
+			serverNetwork:  "",
+			expectedResult: "",
+			expectError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := mapServerNetworkToDaemonNetwork(tt.serverNetwork)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "unsupported network")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedResult, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 📄 Description

We are getting this error in production:

```
│ {"level":"fatal","msg":"network mismatch: daemon expected mainnet, server's got bitcoin","time":"2025-07-09T11:31:52Z"} 
```      

## 🐛  Solution

Production deployment fails with network mismatch: daemon expects `"mainnet", "regtest", "testnet"`. Backend works with `'bitcoin', 'regtest', 'testnet'`. Implemented a network mappe that translates server response before parsing, mapping `"bitcoin"` → "`mainnet"` while preserving existing "testnet" and "regtest" values. Added comprehensive test coverage for all mapping scenarios including error handling for unsupported networks.


⚠️ **Technical debt note**: This mapper serves as a compatibility layer for immediate production stability. Long-term solution should standardize both services to use consistent Bitcoin network naming ("mainnet", "testnet", "regtest") and remove the translation logic.