### PR TITLE
Add outgoing channel to bitfinex swap

### DIFF
--- a/server-backend/src/LndService.ts
+++ b/server-backend/src/LndService.ts
@@ -17,51 +17,29 @@ export class LndService {
         this.logger.debug(`paying invoice ${invoice} with cltvLimit=${cltvLimit}`);
         if (channel) {
             this.logger.debug(`attempting to pay through specific channel ${channel}`);
-            return new Promise((resolve, reject) => {
-                this.lightning.sendPaymentSync(
-                    {
-                        paymentRequest: invoice,
-                        outgoingChanId: channel,
-                        cltvLimit,
-                        finalCltvDelta: 20,
-                    },
-                    (err, value) => {
-                        if (err) {
-                            this.logger.debug(`error paying invoice ${err}`);
-                            reject(err);
-                        } else if (value?.paymentPreimage != null) {
-                            this.logger.debug(`payment success, preimage ${value?.paymentPreimage.toString('hex')}`);
-                            resolve(value.paymentPreimage!);
-                        } else {
-                            this.logger.debug(`error paying invoice ${value?.paymentError}`);
-                            reject(new Error(`error paying invoice ${value?.paymentError}`));
-                        }
-                    },
-                );
-            });
-        } else {
-            return new Promise((resolve, reject) => {
-                this.lightning.sendPaymentSync(
-                    {
-                        paymentRequest: invoice,
-                        cltvLimit,
-                        finalCltvDelta: 20,
-                    },
-                    (err, value) => {
-                        if (err) {
-                            this.logger.debug(`error paying invoice ${err}`);
-                            reject(err);
-                        } else if (value?.paymentPreimage != null) {
-                            this.logger.debug(`payment success, preimage ${value?.paymentPreimage.toString('hex')}`);
-                            resolve(value.paymentPreimage!);
-                        } else {
-                            this.logger.debug(`error paying invoice ${value?.paymentError}`);
-                            reject(new Error(`error paying invoice ${value?.paymentError}`));
-                        }
-                    },
-                );
-            });
         }
+        return new Promise((resolve, reject) => {
+            this.lightning.sendPaymentSync(
+                {
+                    paymentRequest: invoice,
+                    outgoingChanId: channel ?? undefined,
+                    cltvLimit,
+                    finalCltvDelta: 20,
+                },
+                (err, value) => {
+                    if (err) {
+                        this.logger.debug(`error paying invoice ${err}`);
+                        reject(err);
+                    } else if (value?.paymentPreimage != null) {
+                        this.logger.debug(`payment success, preimage ${value?.paymentPreimage.toString('hex')}`);
+                        resolve(value.paymentPreimage!);
+                    } else {
+                        this.logger.debug(`error paying invoice ${value?.paymentError}`);
+                        reject(new Error(`error paying invoice ${value?.paymentError}`));
+                    }
+                },
+            );
+        });
     }
 
     getNewAddress(): Promise<string> {

--- a/server-backend/src/LndService.ts
+++ b/server-backend/src/LndService.ts
@@ -13,29 +13,56 @@ export class LndService {
         @Inject('lnd-invoices') private invoices: InvoicesClient,
     ) {}
 
-    async sendPayment(invoice: string, cltvLimit: number): Promise<Buffer> {
+    async sendPayment(invoice: string, cltvLimit: number, channel: number | string | null = null): Promise<Buffer> {
         this.logger.debug(`paying invoice ${invoice} with cltvLimit=${cltvLimit}`);
-        return new Promise((resolve, reject) => {
-            this.lightning.sendPaymentSync(
-                {
-                    paymentRequest: invoice,
-                    cltvLimit,
-                    finalCltvDelta: 20,
-                },
-                (err, value) => {
-                    if (err) {
-                        this.logger.debug(`error paying invoice ${err}`);
-                        reject(err);
-                    } else if (value?.paymentPreimage != null) {
-                        this.logger.debug(`payment success, preimage ${value?.paymentPreimage.toString('hex')}`);
-                        resolve(value.paymentPreimage!);
-                    } else {
-                        this.logger.debug(`error paying invoice ${value?.paymentError}`);
-                        reject(new Error(`error paying invoice ${value?.paymentError}`));
-                    }
-                },
-            );
-        });
+        if (channel) {
+            this.logger.debug(`attempting to pay through specific channel ${channel}`);
+            return new Promise((resolve, reject) => {
+                this.lightning.sendPaymentSync(
+                    {
+                        paymentRequest: invoice,
+                        outgoingChanId: channel,
+                        cltvLimit,
+                        finalCltvDelta: 20,
+                    },
+                    (err, value) => {
+                        if (err) {
+                            this.logger.debug(`error paying invoice ${err}`);
+                            reject(err);
+                        } else if (value?.paymentPreimage != null) {
+                            this.logger.debug(`payment success, preimage ${value?.paymentPreimage.toString('hex')}`);
+                            resolve(value.paymentPreimage!);
+                        } else {
+                            this.logger.debug(`error paying invoice ${value?.paymentError}`);
+                            reject(new Error(`error paying invoice ${value?.paymentError}`));
+                        }
+                    },
+                );
+            });
+
+        } else{
+            return new Promise((resolve, reject) => {
+                this.lightning.sendPaymentSync(
+                    {
+                        paymentRequest: invoice,
+                        cltvLimit,
+                        finalCltvDelta: 20,
+                    },
+                    (err, value) => {
+                        if (err) {
+                            this.logger.debug(`error paying invoice ${err}`);
+                            reject(err);
+                        } else if (value?.paymentPreimage != null) {
+                            this.logger.debug(`payment success, preimage ${value?.paymentPreimage.toString('hex')}`);
+                            resolve(value.paymentPreimage!);
+                        } else {
+                            this.logger.debug(`error paying invoice ${value?.paymentError}`);
+                            reject(new Error(`error paying invoice ${value?.paymentError}`));
+                        }
+                    },
+                );
+            });
+        }
     }
 
     getNewAddress(): Promise<string> {

--- a/server-backend/src/LndService.ts
+++ b/server-backend/src/LndService.ts
@@ -39,8 +39,7 @@ export class LndService {
                     },
                 );
             });
-
-        } else{
+        } else {
             return new Promise((resolve, reject) => {
                 this.lightning.sendPaymentSync(
                     {

--- a/server-backend/src/cli.ts
+++ b/server-backend/src/cli.ts
@@ -287,11 +287,7 @@ program
         try {
             console.log('⚡ Paying Lightning invoice using LND');
             const provider = await getBitfinexProvider();
-            const result = await provider.payInvoice(
-                cmdOptions.invoice,
-                cmdOptions.channel,
-                parseInt(cmdOptions.cltvLimit)
-            );
+            const result = await provider.payInvoice(cmdOptions.invoice, cmdOptions.channel, parseInt(cmdOptions.cltvLimit));
 
             if (result.success) {
                 console.log('✅ Payment successful!');

--- a/server-backend/src/providers/BitfinexProvider.ts
+++ b/server-backend/src/providers/BitfinexProvider.ts
@@ -180,8 +180,9 @@ export class BitfinexProvider extends SwapProvider {
      * Executes a complete swap operation: amount BTC → Lightning → Liquid.
      * @param amount - Amount to swap in BTC
      * @param liquidAddress - Destination Liquid wallet address
+     * @param channel - Optional specific channel ID to use for the payment
      */
-    async swap(amount: number, liquidAddress?: string): Promise<void> {
+    async swap(amount: number, liquidAddress?: string, channel?: string | number): Promise<void> {
         console.log(`🔄 Starting complete swap: ${amount} BTC → Lightning → Liquid`);
 
         try {
@@ -214,7 +215,7 @@ export class BitfinexProvider extends SwapProvider {
             }
 
             // Step 3: Pay the invoice using LND service
-            const paymentResult = await this.payInvoice(invoice, 0);
+            const paymentResult = await this.payInvoice(invoice, 0, channel);
 
             if (!paymentResult.success) {
                 throw new Error(`Payment failed: ${paymentResult.error}`);
@@ -339,12 +340,14 @@ export class BitfinexProvider extends SwapProvider {
      * Pays a Lightning Network invoice using the configured LND service.
      * @param invoice - Lightning invoice payment request string
      * @param cltvLimit - CLTV limit for the payment (default: 0)
+     * @param channel - Optional specific channel ID to use for the payment (default: null)
      * @param options - Additional payment options (timeout, maxFeePercent)
      * @returns Promise resolving to payment result with success status and preimage
      */
     async payInvoice(
         invoice: string,
         cltvLimit: number = 0,
+        channel: number | string | null = null,
         options: {
             timeout?: number;
             maxFeePercent?: number;
@@ -362,7 +365,7 @@ export class BitfinexProvider extends SwapProvider {
 
         try {
             console.log(`🚀 Initiating payment through LND...`);
-            const preimage = await this.lndService.sendPayment(invoice, cltvLimit);
+            const preimage = await this.lndService.sendPayment(invoice, cltvLimit, channel);
             const preimageHex = preimage.toString('hex');
 
             console.log(`✅ Payment successful!`);


### PR DESCRIPTION
## 📄 Description
Now we can set the outgoing channel for the `lnd` payment within the Bitfinex CLI swap command.

Using `outgoingChanId` property from `SendRequest`:

```
export interface SendRequest {
  'dest'?: (Buffer | Uint8Array | string);
  'destString'?: (string);
  'amt'?: (number | string | Long);
  'paymentHash'?: (Buffer | Uint8Array | string);
  'paymentHashString'?: (string);
  'paymentRequest'?: (string);
  'finalCltvDelta'?: (number);
  'feeLimit'?: (_lnrpc_FeeLimit | null);
  'outgoingChanId'?: (number | string | Long);  <--- This property
  'cltvLimit'?: (number);
  'destCustomRecords'?: ({[key: number]: Buffer | Uint8Array | string});
  'amtMsat'?: (number | string | Long);
  'lastHopPubkey'?: (Buffer | Uint8Array | string);
  'allowSelfPayment'?: (boolean);
  'destFeatures'?: (_lnrpc_FeatureBit)[];
  'paymentAddr'?: (Buffer | Uint8Array | string);
}
```

According to `payinvoice --help` comand:

```
--outgoing_chan_id value     short channel id of the outgoing channel to use for the first hop of the payment; can be specified multiple times in the same command
```